### PR TITLE
Call createMigration (via the callback) if the migrations directory already exists

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -52,6 +52,8 @@ function createMigrationDir(dir, callback) {
   fs.stat(dir, function(err, stat) {
     if (err) {
       fs.mkdir(dir, callback);
+    } else {
+      callback();
     }
   });
 }


### PR DESCRIPTION
With the refactoring in 38cfdf8f, executeCreate never calls createMigration if the migration directory already exists.
