### PR TITLE
Run migrations oldest to newest

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -103,7 +103,7 @@ Migration.loadFromFilesystem = function(dir, callback) {
     files = files.filter(function(file) {
       return /\.js$/.test(file);
     })
-    var migrations = files.map(function(file) {
+    var migrations = files.sort().map(function(file) {
       return new Migration(path.join(dir, file));
     });
     callback(null, migrations);


### PR DESCRIPTION
The migrations were being run newest to oldest.  This caused errors about "table does not exist" when trying to add a column in a different migration.
