### PR TITLE
PostgreSQL does not support IF NOT EXISTS for CREATE TABLE

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -32,6 +32,18 @@ var PgDriver = Base.extend({
         return this._super(str);
     },
 
+    createMigrationsTable: function(callback) {
+      var options = {
+        columns: {
+          'id': { type: type.INTEGER, notNull: true, primaryKey: true, autoIncrement: true },
+          'name': { type: type.STRING, length: 255, notNull: true},
+          'run_on': { type: type.DATE_TIME, notNull: true}
+        },
+        ifNotExists: false
+      }
+      this.createTable('migrations', options, callback);
+    },
+
     createColumnConstraint: function(spec, options) {
         var constraint = [];
         if (spec.primaryKey && options.emitPrimaryKey) {


### PR DESCRIPTION
I would override this in drivers/Base.createTable() but there was no simple mechanism without a fair bit of restructuring.

Without disabling this check, you cannot initialize the migrations table in pg.

I would have added a test, but there aren't any :)
