### PR TITLE
Fix string type for PostgreSQL

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -24,6 +24,8 @@ var PgDriver = Base.extend({
     },
     mapDataType: function(str) {
         switch(str) {
+          case type.STRING:
+            return 'VARCHAR';
           case type.DATE_TIME:
             return 'TIMESTAMP';
           case type.BLOG:


### PR DESCRIPTION
node-db-migrate is currently treating 'string' types as TEXT in Postgres.  This should be a VARCHAR instead.
