### PR TITLE
Respect column length attribute

### DIFF
--- a/lib/driver/base.js
+++ b/lib/driver/base.js
@@ -36,7 +36,10 @@ module.exports = Base = Class.extend({
   },
 
   createColumnDef: function(name, spec, options) {
-    return [name, this.mapDataType(spec.type), this.createColumnConstraint(spec, options)].join(' ');
+    var type       = this.mapDataType(spec.type);
+    var len        = spec.length ? util.format('(%s)', spec.length) : '';
+    var constraint = this.createColumnConstraint(spec, options);
+    return [name, type, len, constraint].join(' ');
   },
 
   createMigrationsTable: function(callback) {

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -11,6 +11,7 @@ var PgDriver = Base.extend({
         this.connection = connection;
         this.connection.connect();
     },
+
     startMigration: function(cb){
         this.runSql('BEGIN;', function() { cb()});
     },
@@ -20,8 +21,12 @@ var PgDriver = Base.extend({
     },
 
     createColumnDef: function(name, spec, options) {
-        return [name, spec.autoIncrement ? '' : this.mapDataType(spec.type), this.createColumnConstraint(spec, options)].join(' ');
+        var type = spec.autoIncrement ? '' : this.mapDataType(spec.type);
+        var len = spec.length ? util.format('(%s)', spec.length) : '';
+        var constraint = this.createColumnConstraint(spec, options);
+        return [name, type, len, constraint].join(' ');
     },
+
     mapDataType: function(str) {
         switch(str) {
           case type.STRING:


### PR DESCRIPTION
It appears that the `createMigrationsTable` was attempting to create columns with a `length` attribute that was being ignored.  This pull request will respect length when specified.
