### PR TITLE
Allow development environment as default for Express.js compatibility

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,22 +25,24 @@ exports.load = function(fileName, currentEnv) {
   } else if(config['default']) {
     setCurrent(config['default']);
   } else {
-    setCurrent('dev');
+    setCurrent(['dev', 'development']);
   }
 
   delete exports.load;
 };
 
 var setCurrent = exports.setCurrent = function(env) {
-  var current = env;
-  if (dbmUtil.isString(env)) {
-    if(!exports[env]) {
-      throw new Error("Environment '" + env + "' not found.");
-    }
-    var current = exports[env];
-  }
+  env = dbmUtil.isArray(env) ? env : [env];
 
-  exports.getCurrent = function() {
-    return current;
+  env.forEach(function (current) {
+    if (dbmUtil.isString(current) && exports[current]) {
+      exports.getCurrent = function() {
+        return exports[current];
+      }
+    }
+  });
+
+  if (!exports.getCurrent) {
+    throw new Error("Environment(s) '" + env.join(', ') + "' not found.");
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,10 +23,14 @@ exports.toArray = function(obj) {
   return arr;
 };
 
+exports.isArray = function(obj) {
+  return Object.prototype.toString.call(obj) == '[object Array]';
+};
+
 exports.isFunction = function(obj) {
   return typeof(obj) == 'function';
-}
+};
 
 exports.isString = function(obj) {
   return typeof(obj) == 'string';
-}
+};


### PR DESCRIPTION
The default fallback environment for node-db-migrate was previously "dev".  Express.js (and perhaps other libraries) defaults to "development".  This pull request will test both "dev" and "development" as fallback environments.
