### PR TITLE
Fixed error with removeIndex in mySQL

### DIFF
--- a/lib/driver/mysql.js
+++ b/lib/driver/mysql.js
@@ -49,6 +49,10 @@ var MysqlDriver = Base.extend({
     this.runSql(sql, callback);
   },
 
+  removeIndex: function(tableName, indexName, callback) {
+    var sql = util.format('DROP INDEX %s ON %s', indexName, tableName);
+    this.runSql(sql, callback);
+  },
 //  renameColumn: function(tableName, oldColumnName, newColumnName, callback) {
 //  },
 

--- a/test/driver/mysql_test.js
+++ b/test/driver/mysql_test.js
@@ -369,10 +369,11 @@ vows.describe('mysql').addBatch({
     topic: function() {
       driver.connect({ driver: 'mysql', database: 'db_migrate_test' }, function(err, db) {
         db.createTable('event', {
-          id: { type: dataType.INTEGER, primaryKey: true, autoIncrement: true }
+          id: { type: dataType.INTEGER, primaryKey: true, autoIncrement: true },
+          title: { type: dataType.STRING }
         }, function() {
           db.addIndex('event', 'event_title', 'title', function(err) {
-            db.removeIndex('event_title', this.callback.bind(this, null, db));
+            db.removeIndex('event', 'event_title', this.callback.bind(this, null, db));
           }.bind(this));
         }.bind(this));
       }.bind(this));


### PR DESCRIPTION
The removeIndex method created sql statements for dropping indexes that was not compatible with mySQL. These changes fix this, as shown in the altered test.
