### PR TITLE
fix for 'spec' is not defined

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -131,7 +131,7 @@ var PgDriver = Base.extend({
           if (typeof columnSpec.defaultValue == 'string'){
             defaultValue = "'" + columnSpec.defaultValue + "'";
           } else {
-            defaultValue = spec.defaultValue;
+            defaultValue = columnSpec.defaultValue;
           }
           sql = util.format("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s", tableName, columnName, defaultValue);
         } else {


### PR DESCRIPTION
I was having a problem using node-db-migrate with a Postgres backend to change a column, adding a default value that was a number.  The problem is setDefaultValue() is referencing a variable called 'spec', but there is no such variable in the scope.  I'm pretty sure this was supposed to be 'columnSpec', and I changed it to that and it appears to work.  Please pull this change into your repo.
