### PR TITLE
handle unique constraints in changeColumn() for postgres

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -116,7 +116,26 @@ var PgDriver = Base.extend({
       function setNotNull() {
         var setOrDrop = columnSpec.notNull === true ? 'SET' : 'DROP';
         var sql = util.format("ALTER TABLE %s ALTER COLUMN %s %s NOT NULL", tableName, columnName, setOrDrop);
-        this.runSql(sql, setDefaultValue.bind(this));
+        this.runSql(sql, setUnique.bind(this));
+      }
+
+      function setUnique(err) {
+        if (err) {
+          callback(err);
+        }
+
+        var sql;
+        var constraintName = tableName + '_' + columnName + '_unique';
+
+        if (columnSpec.unique === true) {
+          sql = util.format("ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)", tableName, constraintName, columnName);
+          this.runSql(sql, setDefaultValue.bind(this));
+        } else if (columnSpec.unique === false) {
+          sql = util.format("ALTER TABLE %s DROP CONSTRAINT %s", tableName, constraintName);
+          this.runSql(sql, setDefaultValue.bind(this));
+        }
+
+        setDefaultValue.call(this);
       }
 
       function setDefaultValue(err) {


### PR DESCRIPTION
There doesn't seem to be support for unique constraints passed to the changeColumn() function for the Postgres backend; they just get ignored.  I added support for it.  Please pull this change into your repo.
