### PR TITLE
Added support for process.env.DATABASE_URL as used by heroku

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -192,6 +192,6 @@ var PgDriver = Base.extend({
 });
 
 exports.connect = function(config, callback) {
-    var db = config.db || new pg.Client(config);
+    var db = config.db || new pg.Client(process.env.DATABASE_URL || config);
     callback(null, new PgDriver(db));
 };


### PR DESCRIPTION
Only affects the pg driver and should work as usual if process.env.DATABASE_URL is not present
