### PR TITLE
Added --version flag

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -9,6 +9,7 @@ var optimist = require('optimist');
 var config = require('../lib/config.js');
 var index = require('../index');
 var log = require('../lib/log');
+var pkginfo = require('pkginfo')(module, 'version');
 
 process.on('uncaughtException', function(err) {
   log.error(err.stack);
@@ -55,7 +56,7 @@ var argv = optimist
     .argv;
 
 if (argv.version) {
-  console.log(index.version);
+  console.log(module.exports.version);
   process.exit(0);
 }
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,3 @@ exports.createMigration = function(title, migrationsDir, callback) {
     callback(null, migration);
   });
 };
-
-// Must be manually synced with that of package.json.
-exports.version = '0.3.2';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "async": "~0.1.15",
     "semver": "~1.0.14",
     "mkdirp": "~0.3.4",
-    "moment": "~1.7.2"
+    "moment": "~1.7.2",
+    "pkginfo": "~0.3.0"
   },
   "devDependencies": {
     "vows": "~0.6.2",


### PR DESCRIPTION
I kept the current version number, so db-migrate --version currently prints like:

```
$ db-migrate --version
0.3.2
```
