### PR TITLE
Lazily require migration

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -75,11 +75,15 @@ Migration = function() {
     this.name = Migration.parseName(this.path);
     this.date = parseDate(this.name);
     this.title = parseTitle(this.name);
-
-    var migrationFile = require(this.path);
-    this._up = migrationFile.up;
-    this._down = migrationFile.down;
   }
+};
+
+Migration.prototype._up = function() {
+  return require(this.path).up.apply(this, arguments);
+};
+
+Migration.prototype._down = function() {
+  return require(this.path).down.apply(this, arguments);
 };
 
 Migration.prototype.write = function(callback) {


### PR DESCRIPTION
This allows migrations to be squashed.

See https://github.com/nearinfinity/node-db-migrate/issues/77
