### PR TITLE
Fix for postgres driver blindly recreating the migrations table

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -62,7 +62,17 @@ var PgDriver = Base.extend({
           }
         }
 
-        this.createTable('migrations', options, callback);
+        this.runSql("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'migrations'", function(err, result) {
+          if(err) {
+            return callback(err);
+          }
+
+          if (result.rows && result.rows.length < 1) {
+            this.createTable('migrations', options, callback);
+          } else {
+            callback();
+          }
+        });
       }.bind(this));
     },
 


### PR DESCRIPTION
Despite this ticket: https://github.com/nearinfinity/node-db-migrate/issues/20 being marked as closed, I'm still experiencing this problem with the latest version.

As it exists now, the createMigrationsTable function in the pg driver has ifNotExists: false, which I assume is because pg doesn't support IF NOT EXISTS create statements. This results in the migrations table getting recreated each time the migrations are run, which results in a crash after the first run.

This change fixes the issue by querying the information_schema.tables table to check for the existence of a migrations table. If it exists, the creation of the table is skipped.
