### PR TITLE
Let DATABASE_URL configure any database.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ exports.up = function (db, callback) {
 exports.down = function (db, callback) {
   db.dropTable('pets', function(err) {
     if (err) { callback(err); return; }
-    db.dropTable('owners', callback); 
+    db.dropTable('owners', callback);
   });
 };
 ```
@@ -204,7 +204,7 @@ You can pass the -e or --env option to db-migrate to select the environment you 
 
 The above will run all migrations that haven't yet been run in the prod environment, grabbing the settings from config/database.json.
 
-Alternatively, for PostgreSQL, you can specify a DATABASE_URL
+Alternatively, you can specify a DATABASE_URL
 environment variable that will be used in place of the configuration
 file settings. This is helpful for use with Heroku.
 
@@ -377,6 +377,21 @@ __Arguments__
 * sql - the SQL query string, possibly with ? replacement parameters
 * params - zero or more ? replacement parameters
 * callback(err, results) - callback that will be invoked after executing the SQL
+
+## Development
+
+The following command runs the vows tests.
+
+```bash
+npm test
+```
+
+Running the tests requires a one-time setup of the MySQL and Postgres databases.
+
+```bash
+mysql -u root -e "CREATE DATABASE db_migrate_test;"
+createdb db_migrate_test
+```
 
 ## License
 

--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -82,7 +82,11 @@ function createMigrationDir(dir, callback) {
 }
 
 function loadConfig() {
-  config.load(argv.config, argv.env);
+  if (process.env["DATABASE_URL"]) {
+    config.loadUrl(process.env["DATABASE_URL"], argv.env);
+  } else {
+    config.load(argv.config, argv.env);
+  }
   if(verbose) {
     var current = config.getCurrent();
     log.info("Using", current.env, "settings:", current.settings);

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var parseDatabaseUrl = require('parse-database-url');
 var dbmUtil = require('./util');
 
 exports.load = function(fileName, currentEnv) {
@@ -29,7 +30,22 @@ exports.load = function(fileName, currentEnv) {
   }
 
   delete exports.load;
+  delete exports.loadUrl;
 };
+
+exports.loadUrl = function(databaseUrl, currentEnv) {
+  var config = parseDatabaseUrl(databaseUrl);
+  if (currentEnv) {
+    exports[currentEnv] = config;
+    setCurrent(currentEnv);
+  } else {
+    exports.urlConfig = config;
+    setCurrent('urlConfig');
+  }
+
+  delete exports.load;
+  delete exports.loadUrl;
+}
 
 var setCurrent = exports.setCurrent = function (env) {
   env = dbmUtil.isArray(env) ? env : [env];

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -198,6 +198,6 @@ var PgDriver = Base.extend({
 });
 
 exports.connect = function(config, callback) {
-    var db = config.db || new pg.Client(process.env.DATABASE_URL || config);
+    var db = config.db || new pg.Client(config);
     callback(null, new PgDriver(db));
 };

--- a/lib/driver/postgres.js
+++ b/lib/driver/postgres.js
@@ -1,0 +1,1 @@
+module.exports = require('./pg');

--- a/package.json
+++ b/package.json
@@ -43,11 +43,15 @@
     "semver": "~1.0.14",
     "mkdirp": "~0.3.4",
     "moment": "~1.7.2",
-    "pkginfo": "~0.3.0"
+    "pkginfo": "~0.3.0",
+    "parse-database-url": "~0.1.0"
   },
   "devDependencies": {
     "vows": "~0.7.0",
-    "db-meta": "~0.4.1"
+    "db-meta": "~0.4.1",
+    "mysql": "~2.0.0",
+    "pg": "~1.0.0",
+    "sqlite3": "~2.1.0"
   },
   "scripts": {
     "test": "node_modules/.bin/vows"

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -3,16 +3,25 @@ var assert = require('assert');
 var config = require('../lib/config');
 var path = require('path');
 
+var _configLoad = config.load;
+var _configLoadUrl = config.loadUrl;
+
 vows.describe('config').addBatch({
-  'library': {
+  'loading from a file': {
     topic: function() {
       var configPath = path.join(__dirname, 'database.json');
+      config.load = _configLoad;
+      config.loadUrl = _configLoadUrl;
       config.load(configPath, 'dev');
       return config;
     },
 
     'should remove the load function': function (config) {
       assert.isUndefined(config.load);
+    },
+
+    'should remove the loadUrl function': function (config) {
+      assert.isUndefined(config.loadUrl);
     },
 
     'should export all environment settings': function (config) {
@@ -27,6 +36,39 @@ vows.describe('config').addBatch({
       assert.equal(current.env, 'dev');
       assert.equal(current.settings.driver, 'sqlite3');
       assert.equal(current.settings.filename, ':memory:');
+    }
+  }
+}).addBatch({
+  'loading from an URL': {
+    topic: function() {
+      var databaseUrl = 'postgres://uname:pw@server.com/dbname';
+      config.load = _configLoad;
+      config.loadUrl = _configLoadUrl;
+      config.loadUrl(databaseUrl, 'dev');
+      return config;
+    },
+
+    'should remove the load function': function (config) {
+      assert.isUndefined(config.load);
+    },
+
+    'should remove the loadUrl function': function (config) {
+      assert.isUndefined(config.loadUrl);
+    },
+
+    'should export the settings as the current environment': function (config) {
+      assert.isDefined(config.dev);
+    },
+
+    'should export a getCurrent function with all current environment settings': function (config) {
+      assert.isDefined(config.getCurrent);
+      var current = config.getCurrent();
+      assert.equal(current.env, 'dev');
+      assert.equal(current.settings.driver, 'postgres');
+      assert.equal(current.settings.user, 'uname');
+      assert.equal(current.settings.password, 'pw');
+      assert.equal(current.settings.host, 'server.com');
+      assert.equal(current.settings.database, 'dbname');
     }
   }
 }).export(module);


### PR DESCRIPTION
This change introduces a parser for the `DATABASE_URL` environment variable early in the configuration stage, so it can be used to configure any database using any driver.

`db-migrate` already supports using `DATABASE_URL` in the Postgres driver. This change makes the support generic.

I hope that you will consider merging it! I'll be happy to address any feedback about the code structure or style.

Thank you very much for `db-migrate`!
