### PR TITLE
Increase cygwin compatibility for 'npm test' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "db-meta": "~0.4.1"
   },
   "scripts": {
-    "test": "node_modules/.bin/vows"
+    "test": "sh node_modules/.bin/vows"
   }
 }


### PR DESCRIPTION
`npm test` was borking in cygwin, so I prefixed the dot slash command with `sh`.
