### PR TITLE
Mitigate `npm test` permission error

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "sqlite3": "~2.1.0"
   },
   "scripts": {
-    "test": "sh node_modules/.bin/vows"
+    "test": "node node_modules/.bin/vows"
   }
 }


### PR DESCRIPTION
`sh node_modules/.bin/vows` should work, as `vows` has a good shebang line. However, on Mac OS X, somehow `vows` is still being interpreted as a shell script:

```
node_modules/.bin/vows: line 4: syntax error near unexpected token `('
node_modules/.bin/vows: line 4: `var path   = require('path'),'
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

Fortunately, this is easily fixed by manually calling `vows` with `node` rather than `sh`.
