### PR TITLE
support database URLs in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,13 @@ db-migrate supports the concept of environments. For example, you might have a d
     "password": "test",
     "host": "localhost",
     "database": "mydb"
-  }
+  },
+
+  "other": "postgres://uname:pw@server.com/dbname"
 }
 ```
+
+Note that if the settings for an environment are represented by a single string that string will be parsed as a database URL.
 
 You can pass the -e or --env option to db-migrate to select the environment you want to run migrations against. The --config option can be used to specify the path to your database.json file if it's not in the current working directory.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,7 +18,10 @@ exports.load = function(fileName, currentEnv) {
   }
 
   for (var env in config) {
-    exports[env] = config[env];
+    if (typeof(config[env]) == "string")
+      exports[env] = parseDatabaseUrl(config[env]);
+    else
+      exports[env] = config[env];
   }
 
   if(currentEnv) {


### PR DESCRIPTION
With this change the database.json can be much shorter. For example:

```
{
    "default": "development",

    "development": "sqlite3://app_debug.sqlite3",
    "test": "sqlite3://app_test.sqlite3",
    "production": "sqlite3://app.sqlite3"
}
```
