### PR TITLE
Provide close callback

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -143,10 +143,12 @@ function executeDown() {
   });
 }
 
-function onComplete(migrator, err) {
-  migrator.driver.close();
-  assert.ifError(err);
-  log.info('Done');
+function onComplete(migrator, originalErr) {
+  migrator.driver.close(function(err) {
+    assert.ifError(originalErr);
+    assert.ifError(err);
+    log.info('Done');
+  });
 }
 
 function run() {

--- a/lib/driver/mysql.js
+++ b/lib/driver/mysql.js
@@ -121,11 +121,11 @@ var MysqlDriver = Base.extend({
     var sql = util.format('DROP INDEX %s ON %s', indexName, tableName);
     this.runSql(sql, callback);
   },
-  
+
   renameColumn: function(tableName, oldColumnName, newColumnName, callback) {
     var self = this, columnTypeSql = util.format("SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '%s' AND COLUMN_NAME = '%s'", tableName, oldColumnName);
     this.all(columnTypeSql, function(err, result) {
-      var columnType = result[0].COLUMN_TYPE; 
+      var columnType = result[0].COLUMN_TYPE;
       var alterSql = util.format("ALTER TABLE %s CHANGE %s %s %s", tableName, oldColumnName, newColumnName, columnType);
       self.runSql(alterSql, callback);
     });
@@ -155,8 +155,8 @@ var MysqlDriver = Base.extend({
     return this.connection.query.apply(this.connection, arguments);
   },
 
-  close: function() {
-    this.connection.end();
+  close: function(callback) {
+    this.connection.end(callback);
   }
 
 });

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -201,8 +201,9 @@ var PgDriver = Base.extend({
         }]);
     },
 
-    close: function() {
+    close: function(callback) {
         this.connection.end();
+        callback(null);
     }
 
 });

--- a/lib/driver/sqlite3.js
+++ b/lib/driver/sqlite3.js
@@ -65,8 +65,9 @@ var Sqlite3Driver = Base.extend({
     this.connection.all.apply(this.connection, arguments);
   },
 
-  close: function() {
+  close: function(callback) {
     this.connection.close();
+    callback(null);
   }
 
 });


### PR DESCRIPTION
The MySQL driver provides a callback when connection.end() is complete. This patch waits for that callback before allowing db-migrate to exit.
