### PR TITLE
Exit process when done

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -152,6 +152,7 @@ function onComplete(migrator, originalErr) {
     assert.ifError(originalErr);
     assert.ifError(err);
     log.info('Done');
+    process.exit();
   });
 }
 


### PR DESCRIPTION
Sometimes db-migrate doesn't exit if you leave some connections open (redis for example), it just hangs there. This will force the process to exit after every migration is done. (`mocha` also does this because it's common to leave some connections opened when testing)
