### PR TITLE
Ability to create "camelCased" columns for PostgreSQL

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -24,7 +24,7 @@ var PgDriver = Base.extend({
         var type = spec.autoIncrement ? '' : this.mapDataType(spec.type);
         var len = spec.length ? util.format('(%s)', spec.length) : '';
         var constraint = this.createColumnConstraint(spec, options);
-        return [name, type, len, constraint].join(' ');
+        return ['"' + name + '"', type, len, constraint].join(' ');
     },
 
     mapDataType: function(str) {


### PR DESCRIPTION
At this moment next code

``` javascript
db.createTable('owners', {
    id: { type: 'int', primaryKey: true },
    displayName: 'string'
}, callback);
```

creates table with columns: id, displayname (without camelcase, what is not good). This pull request fixes this issue.
