### PR TITLE
Fix #82 dry-run-on-first-migration-fails

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -57,7 +57,7 @@ var PgDriver = Base.extend({
           return callback(err);
         }
 
-        if (result.rows && result.rows.length > 0 && result.rows[0].version) {
+        if (result && result.rows && result.rows.length > 0 && result.rows[0].version) {
           var version = result.rows[0].version;
           var match = version.match(/\d+\.\d+\.\d+/);
           if (match && match[0] && semver.gte(match[0], '9.1.0')) {
@@ -70,7 +70,7 @@ var PgDriver = Base.extend({
             return callback(err);
           }
 
-          if (result.rows && result.rows.length < 1) {
+          if (result && result.rows && result.rows.length < 1) {
             this.createTable('migrations', options, callback);
           } else {
             callback();


### PR DESCRIPTION
Just checking that result is defined :
When using `--dry-run`, `PgDriver.runSql` return the callback with no parameters.
As we don't really run the query against the database, we don't have any result.
