### PR TITLE
Added ability to specify a full connection string via an environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,16 @@ You can also specify environment variables in your config file by using a specia
   },
 }
 ```
+
+You can also specify an environment variable for the full connection string using the databaseUrl key:
+```javascript
+{
+  "prod": {
+    "databaseUrl": {"ENV": "DATABASE_URL"}
+  }
+}
+```
+
 In this case, db-migrate will search your environment for variables
 called `PRODUCTION_USERNAME` and `PRODUCTION_PASSWORD`, and use those values for the corresponding configuration entry.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,6 +20,9 @@ exports.load = function(fileName, currentEnv) {
   for (var env in config) {
     if (typeof(config[env]) == "string") {
       exports[env] = parseDatabaseUrl(config[env]);
+    } else if (config[env].databaseUrl != null &&
+               config[env]["databaseUrl"].ENV != null) {
+      exports[env] = parseDatabaseUrl(config[env]["databaseUrl"].ENV)
     } else {
       //Check config entry's for ENV objects
       //which will tell us to grab configuration from the environment


### PR DESCRIPTION
Added this for the scenario that db-migrate will use the environment var for a connection string in Heroku.
