### PR TITLE
Fix postgres issue with camelCased column name during insert

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -174,6 +174,14 @@ var PgDriver = Base.extend({
       }
     },
 
+    insert: function(tableName, columnNameArray, valueArray, callback) {
+      columnNameArray = columnNameArray.map(function(columnName) {
+        return (columnName.charAt(0) != '"') ? '"' + columnName + '"' : columnName;
+      });
+
+      return this._super(tableName, columnNameArray, valueArray, callback);
+    },
+
     runSql: function() {
         var callback = arguments[arguments.length - 1];
 


### PR DESCRIPTION
Similar to #125,  addresses issue found here:
http://stackoverflow.com/questions/14189254/pgerror-error-column-of-relation-does-not-exist-rails-heroku
