### PR TITLE
Allow changing the schema for Postgres.

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ db-migrate supports the concept of environments. For example, you might have a d
     "user": "test",
     "password": "test",
     "host": "localhost",
-    "database": "mydb"
+    "database": "mydb",
+    "schema": "my_schema"
   },
 
   "other": "postgres://uname:pw@server.com/dbname"

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -6,9 +6,10 @@ var type = require('../data_type');
 var log = require('../log');
 
 var PgDriver = Base.extend({
-    init: function(connection) {
+    init: function(connection, schema) {
         this._super();
         this.connection = connection;
+        this.schema = schema || "public";
         this.connection.connect();
     },
 
@@ -65,16 +66,37 @@ var PgDriver = Base.extend({
           }
         }
 
-        this.runSql("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'migrations'", function(err, result) {
-          if (err) {
-            return callback(err);
-          }
-
-          if (result && result.rows && result.rows.length < 1) {
-            this.createTable('migrations', options, callback);
-          } else {
-            callback();
-          }
+        // Get the current search path so we can change the current schema
+        // if necessary
+        this.runSql("SHOW search_path", function(err, result) {
+            if (err) {
+                return callback(err);
+            }
+            
+            var searchPath;
+            
+            // if the user specified a different schema, prepend it to the
+            // search path. This will make all DDL/DML/SQL operate on the specified
+            // schema. 
+            if (this.schema === 'public') {
+                searchPath = result.rows[0].search_path;
+            } else {
+                searchPath = this.schema + ',' + result.rows[0].search_path;
+            }
+            
+            this.runSql('SET search_path TO ' + searchPath, function() {                                                        
+                this.runSql("SELECT table_name FROM information_schema.tables WHERE table_name = 'migrations'", function(err, result) {
+                  if (err) {
+                    return callback(err);
+                  }
+        
+                  if (result && result.rows && result.rows.length < 1) {
+                    this.createTable('migrations', options, callback);
+                  } else {
+                    callback();
+                  }
+                }.bind(this));
+            }.bind(this));
         }.bind(this));
       }.bind(this));
     },
@@ -222,5 +244,5 @@ var PgDriver = Base.extend({
 exports.connect = function(config, callback) {
     if (config.native) { pg = pg.native; }
     var db = config.db || new pg.Client(config);
-    callback(null, new PgDriver(db));
+    callback(null, new PgDriver(db, config.schema));
 };

--- a/test/driver/pg_schema_test.js
+++ b/test/driver/pg_schema_test.js
@@ -1,0 +1,47 @@
+var vows = require('vows');
+var assert = require('assert');
+var dbmeta = require('db-meta');
+var pg = require('pg');
+var dataType = require('../../lib/data_type');
+var driver = require('../../lib/driver');
+
+var client = new pg.Client('postgres://localhost/db_migrate_test');
+
+vows.describe('pg').addBatch({
+    'create schema and connect': {
+        topic: function() {
+            var callback = this.callback;
+            
+            client.connect(function(err) {
+                client.query('CREATE SCHEMA test_schema', function(err) {
+                    driver.connect({ driver: 'pg', database: 'db_migrate_test', schema: 'test_schema' }, function(err, db) {
+                        callback(null, db);
+                    });
+                });
+            });
+        },
+        
+        'migrations table': {
+            topic: function(db) {
+                var callback = this.callback;
+                
+                db.createMigrationsTable(function() {
+                    client.query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'test_schema' AND table_name = 'migrations'", function(err, result) {
+                        callback(err, result);        
+                    });
+                });
+            },
+            
+            'is in test_schema': function(err, result) {
+                assert.isNull(err);
+                assert.isNotNull(result);
+                assert.equal(result.rowCount, 1);
+            }
+        },
+        
+        teardown: function() {
+            client.query('DROP SCHEMA test_schema CASCADE', this.callback);
+        }
+    }
+}).export(module);
+


### PR DESCRIPTION
This primarily just makes it so that the migrations table is per schema rather than always being in public. Migrations still need to explicitly use the schema in the DDL/DML, eg:

CREATE TABLE my_schema.my_table (...)

I was a little iffy on the test. I wasn't sure how you were specifying username/password, so the test might need to be fixed.
