### PR TITLE
Add multiple migration directories for up and down

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -124,7 +124,11 @@ function executeUp() {
   }
   index.connect(config.getCurrent().settings, function(err, migrator) {
     assert.ifError(err);
-    migrator.migrationsDir = path.resolve(argv['migrations-dir']);
+    var migrationsDirs = argv['migrations-dir'].split(',');
+    migrator.migrationsDirs = [];
+    for (var i=0; i<migrationsDirs.length; i++) {
+      migrator.migrationsDirs.push(path.resolve(migrationsDirs[i]));
+    }
     migrator.driver.createMigrationsTable(function(err) {
       assert.ifError(err);
       log.verbose('migration table created');
@@ -139,7 +143,11 @@ function executeDown() {
   }
   index.connect(config.getCurrent().settings, function(err, migrator) {
     assert.ifError(err);
-    migrator.migrationsDir = path.resolve(argv['migrations-dir']);
+    var migrationsDirs = argv['migrations-dir'].split(',');
+    migrator.migrationsDirs = [];
+    for (var i=0; i<migrationsDirs.length; i++) {
+      migrator.migrationsDirs = path.resolve(migrationsDirs[i]);  
+    }
     migrator.driver.createMigrationsTable(function(err) {
       assert.ifError(err);
       migrator.down(argv, onComplete.bind(this, migrator));

--- a/lib/driver/base.js
+++ b/lib/driver/base.js
@@ -65,6 +65,7 @@ module.exports = Base = Class.extend({
       columns: {
         'id': { type: type.INTEGER, notNull: true, primaryKey: true, autoIncrement: true },
         'name': { type: type.STRING, length: 255, notNull: true},
+        'group': { type: type.STRING, length: 255, notNull: true},
         'run_on': { type: type.DATE_TIME, notNull: true}
       },
       ifNotExists: true
@@ -215,8 +216,8 @@ module.exports = Base = Class.extend({
     }
   },
 
-  addMigrationRecord: function (name, callback) {
-    this.runSql('INSERT INTO migrations (name, run_on) VALUES (?, ?)', [name, new Date()], callback);
+  addMigrationRecord: function (name, group, callback) {
+    this.runSql('INSERT INTO migrations (name, "group", run_on) VALUES (?, ?, ?)', [name, group, new Date()], callback);
   },
 
   startMigration: function(cb){cb();},

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -47,6 +47,7 @@ var PgDriver = Base.extend({
         columns: {
           'id': { type: type.INTEGER, notNull: true, primaryKey: true, autoIncrement: true },
           'name': { type: type.STRING, length: 255, notNull: true},
+          'group': { type: type.STRING, length: 255, notNull: true},
           'run_on': { type: type.DATE_TIME, notNull: true}
         },
         ifNotExists: false

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,3 +1,4 @@
+var async = require('async');
 var fs = require('fs');
 var path = require('path');
 var inflection = require('./inflection');
@@ -56,8 +57,16 @@ function parseTitle(name) {
   return inflection.humanize(dashed, true);
 }
 
-function writeMigrationRecord(db, migration, callback) {
-  db._runSql('INSERT INTO migrations (name, run_on) VALUES (?, ?)', [migration.name, new Date()], callback);
+function parseGroup(dir) {
+  dir = path.dirname(dir);
+
+  var relativeDir = path.dirname(dir);
+
+  if (relativeDir!='.') {
+    dir = dir.substring(relativeDir.length + 1);
+  }
+
+  return dir;
 }
 
 var migrationTemplate = [
@@ -80,11 +89,13 @@ Migration = function() {
     this.date = arguments[2];
     this.name = formatName(this.title, this.date);
     this.path = formatPath(arguments[1], this.name);
+    this.group = parseGroup(this.path);
   } else if (arguments.length == 1) {
     this.path = arguments[0];
     this.name = Migration.parseName(this.path);
     this.date = parseDate(this.name);
     this.title = parseTitle(this.name);
+    this.group = parseGroup(this.path);
   }
 };
 
@@ -113,31 +124,46 @@ Migration.parseName = function(path) {
   return match[1];
 };
 
-Migration.loadFromFilesystem = function(dir, callback) {
-  log.verbose('loading migrations from dir', dir);
-  fs.readdir(dir, function(err, files) {
-    if (err) { callback(err); return; }
-    var coffeeWarn = true;
-    files = files.filter(function(file) {
-      if (coffeeWarn && !coffeeSupported && /\.coffee$/.test(file)) {
-        log.warn('CoffeeScript not installed');
-        coffeeWarn = false;
-      }
-      return filesRegEx.test(file);
+Migration.loadFromFilesystem = function(dirs, callback) {
+  async.reduce(dirs, [], function(listOfFiles, dir, next) {
+    log.verbose('loading migrations from dir', dir);
+    fs.readdir(dir, function(err, files) {
+      if (err) { next(err, null); return; }
+      var coffeeWarn = true;
+      files = files.filter(function(file) {
+        if (coffeeWarn && !coffeeSupported && /\.coffee$/.test(file)) {
+          log.warn('CoffeeScript not installed');
+          coffeeWarn = false;
+        }
+        return filesRegEx.test(file);
+      }).map(function(file) {
+        return {filename:file, directory:dir};
+      });
+      next(null, listOfFiles.concat(files));
     });
-    var migrations = files.sort().map(function(file) {
-      return new Migration(path.join(dir, file));
+
+  }, function(err, filesFound){
+    if (err) { callback(err, null); return; }
+    var migrations = filesFound.sort(function(a, b) { 
+      if (a.filename > b.filename)
+        return 1;
+      if (a.filename < b.filename)
+        return -1;
+      // a must be equal to b
+      return 0;
+    }).map(function(fileEntry) {
+      return new Migration(path.join(fileEntry.directory, fileEntry.filename));
     });
     callback(null, migrations);
   });
 };
 
-Migration.loadFromDatabase = function(dir, driver, callback) {
+Migration.loadFromDatabase = function(driver, callback) {
   log.verbose('loading migrations from database');
   driver.all('SELECT * FROM migrations ORDER BY name DESC', function(err, dbResults) {
     if (err) { callback(err); return; }
     var migrations = dbResults.map(function(result) {
-      return new Migration(path.join(dir, result.name));
+      return new Migration(path.join(result.group, result.name));
     });
     callback(null, migrations);
   });

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -48,9 +48,9 @@ function filterDown(completedMigrations, destination, count) {
 }
 
 
-Migrator = function(driver, migrationsDir) {
+Migrator = function(driver, migrationsDirs) {
   this.driver = driver;
-  this.migrationsDir = migrationsDir;
+  this.migrationsDirs = migrationsDirs;
 };
 
 Migrator.prototype = {
@@ -61,13 +61,13 @@ Migrator.prototype = {
   writeMigrationRecord: function(migration, callback) {
     function onComplete(err) {
       if (err) {
-        log.error(migration.name, err);
+        log.error(migration.name+'@'+migration.group, err);
       } else {
         log.info('Processed migration', migration.name);
       }
       callback(err);
     }
-    this.driver.addMigrationRecord(migration.name, onComplete);
+    this.driver.addMigrationRecord(migration.name, migration.group, onComplete);
   },
 
   deleteMigrationRecord: function(migration, callback) {
@@ -108,10 +108,10 @@ Migrator.prototype = {
 
   upToBy: function(partialName, count, callback) {
     var self = this;
-    Migration.loadFromFilesystem(self.migrationsDir, function(err, allMigrations) {
+    Migration.loadFromFilesystem(self.migrationsDirs, function(err, allMigrations) {
       if (err) { callback(err); return; }
 
-      Migration.loadFromDatabase(self.migrationsDir, self.driver, function(err, completedMigrations) {
+      Migration.loadFromDatabase(self.driver, function(err, completedMigrations) {
         if (err) { callback(err); return; }
         var toRun = filterUp(allMigrations, completedMigrations, partialName, count);
 
@@ -144,7 +144,7 @@ Migrator.prototype = {
 
   downToBy: function(partialName, count, callback) {
     var self = this;
-    Migration.loadFromDatabase(self.migrationsDir, self.driver, function(err, completedMigrations) {
+    Migration.loadFromDatabase(self.driver, function(err, completedMigrations) {
       if (err) { return callback(err); }
 
       var toRun = filterDown(completedMigrations, partialName, count);


### PR DESCRIPTION
Note: There are no tests at this point; I am having a lot of issues installing the dev dependencies. I have been using `npm install --dev db-migrate` and I get a lot of *"Error: ENOENT, lstat"* error messages.

As of now, db-migrate reads migration files from a single directory when doing ups/down. This commit adds the capability to include a set of directories, separated by commas, when doing ups/down. This way, you can have greater control of what migrations could run for different environments. Migrations are merged into a single list and sorted by timestamp.

Example:
migrations/1001-create-users-table
migrations/1040-create-logs-table
post_migrations/1005-create-groups-table

After running `db-migrate up -m migrations,post_migrations`, the above migrations will run in this order:
migrations/1001-create-users-table
post_migrations/1005-create-groups-table
migrations/1040-create-logs-table

Other example:
schema/1001-create-users-table
debug/1005-create-debugging-table

You might want to run the following commands depending on your environment:
- *Production*: `db-migrate up -m schema`
- *Development*: `db-migrate up -m schema,debug`

This commit adds an extra column, called `group`, to the *migrations* table. Eventually there will be a need to check if the column exists if this happens to be executed against an existing installation. This extra check will make the change backwards compatible. Let me know if you still want me to do this, should not be complicated. In my case, I am starting fresh, so, I don't need this change. The help text in db-migrate file in bin might need to be updated too.