### PR TITLE
Adds a way to use folders in the migrations dir

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -104,7 +104,7 @@ function executeCreate() {
     process.exit(1);
   }
 
-  createMigrationDir(argv['migrations-dir'], function(err) {
+  createMigrationDir(argv['migrations-dir'] + (argv._[0] && argv._[0].indexOf('/') > -1 ? '/' + argv._[0].substr(0, argv._[0].lastIndexOf('/')) : ''), function(err) {
     if (err) {
       log.error('Failed to create migration directory at ', argv['migrations-dir'], err);
       process.exit(1);

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -64,16 +64,11 @@ function writeMigrationRecord(db, migration, callback) {
 }
 
 var migrationTemplate = [
-  "var dbm = require('db-migrate');",
-  "var type = dbm.dataType;",
+  "var lines = [",
   "",
-  "exports.up = function(db, callback) {",
+  "];",
   "",
-  "};",
-  "",
-  "exports.down = function(db, callback) {",
-  "",
-  "};",
+  "exports.up = function(db, callback) { var i = 0; lines.forEach(function(line){ db.runSql(line, function(err){ if (err) return callback(err); if (++i >= lines.length) callback(); }); }); };",
   ""
 ].join("\n");
 
@@ -83,9 +78,9 @@ Migration = function() {
     this.date = arguments[2];
     this.name = formatName(this.title, this.date);
     this.path = formatPath(arguments[1], this.name);
-  } else if (arguments.length == 1) {
+  } else if (arguments.length == 2) {
     this.path = arguments[0];
-    this.name = Migration.parseName(this.path);
+    this.name = Migration.parseName(this.path, arguments[1]);
     this.date = parseDate(this.name);
     this.title = parseTitle(this.name);
   }
@@ -111,9 +106,8 @@ Migration.prototype.down = function(db, callback) {
   this._down(db, callback);
 };
 
-Migration.parseName = function(path) {
-  var match = path.match(/(\d{14}-[^.]+)(?:\.*?)?/);
-  return match[1];
+Migration.parseName = function(path, dir) {
+  return path.replace(dir + '/', '').replace('.js', '');
 };
 
 Migration.loadFromFilesystem = function(dir, callback) {
@@ -135,8 +129,9 @@ Migration.loadFromFilesystem = function(dir, callback) {
       return filesRegEx.test(file);
     });
     var migrations = files.sort().map(function(file) {
-      return new Migration(path.join(dir, file));
+      return new Migration(path.join(dir, file), dir);
     });
+
     callback(null, migrations);
   });
 };
@@ -146,7 +141,7 @@ Migration.loadFromDatabase = function(dir, driver, callback) {
   driver.all('SELECT * FROM migrations ORDER BY name DESC', function(err, dbResults) {
     if (err) { callback(err); return; }
     var migrations = dbResults.map(function(result) {
-      return new Migration(path.join(dir, result.name));
+      return new Migration(path.join(dir, result.name), dir);
     });
     callback(null, migrations);
   });

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -116,14 +116,14 @@ Migration.parseName = function(path) {
 
 Migration.loadFromFilesystem = function(dir, callback) {
   log.verbose('loading migrations from dir', dir);
-  
   var walker = walk.walk(dir),
       files = [];
-  walk.on('file', function(root, file, next){
-    files.push(root + file);
+  walker.on('file', function(root, file, next){
+    files.push((root.replace(dir, '') + '/').substr(1) + file.name);
+    next();
   });
-  walk.on('end', function(){
-    if (err) { callback(err); return; }
+  walker.on('end', function(){
+    files.sort();
     var coffeeWarn = true;
     files = files.filter(function(file) {
       if (coffeeWarn && !coffeeSupported && /\.coffee$/.test(file)) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var walk = require('walk');
 var inflection = require('./inflection');
 var lpad = require('./util').lpad;
 var config = require('./config');
@@ -115,7 +116,13 @@ Migration.parseName = function(path) {
 
 Migration.loadFromFilesystem = function(dir, callback) {
   log.verbose('loading migrations from dir', dir);
-  fs.readdir(dir, function(err, files) {
+  
+  var walker = walk.walk(dir),
+      files = [];
+  walk.on('file', function(root, file, next){
+    files.push(root + file);
+  });
+  walk.on('end', function(){
     if (err) { callback(err); return; }
     var coffeeWarn = true;
     files = files.filter(function(file) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -68,7 +68,7 @@ var migrationTemplate = [
   "",
   "];",
   "",
-  "exports.up = function(db, cb){ require('async').eachSeries(lines, db.runSql.bind(db), cb); };",
+  "exports.up = function(db, cb){ require('async').eachSeries(lines, function(line, next){ db.runSql(line, next); }, cb); };",
   ""
 ].join("\n");
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -68,7 +68,7 @@ var migrationTemplate = [
   "",
   "];",
   "",
-  "exports.up = function(db, callback) { var i = 0; lines.forEach(function(line){ db.runSql(line, function(err){ if (err) return callback(err); if (++i >= lines.length) callback(); }); }); };",
+  "exports.up = function(db, cb){ require('async').eachSeries(lines, db.runSql.bind(db), cb); };",
   ""
 ].join("\n");
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -68,7 +68,7 @@ var migrationTemplate = [
   "",
   "];",
   "",
-  "exports.up = function(db, cb){ require('async').eachSeries(lines, function(line, next){ db.runSql(line, next); }, cb); };",
+  "exports.up = function(db, cb){ require('async').eachSeries(lines, db.runSql.bind(db), cb); };",
   ""
 ].join("\n");
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -21,7 +21,9 @@ function formatPath(dir, name) {
 }
 
 function formatName(title, date) {
-  return formatDate(date) + '-' + formatTitle(title);
+  var name = formatTitle(title).split('/');
+  name[name.length - 1] = formatDate(date) + '-' + name[name.length -1];
+  return name.join('/');
 }
 
 function formatDate(date) {

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -1,169 +1,151 @@
-var async = require('async');
-var dbmUtil = require('./util');
-var Migration = require('./migration');
+var fs = require('fs');
+var path = require('path');
+var walk = require('walk');
+var inflection = require('./inflection');
+var lpad = require('./util').lpad;
+var config = require('./config');
 var log = require('./log');
 
-function isIncludedInUp(migration, destination) {
-  if(!destination) {
-    return true;
-  }
-  var migrationTest = migration.name.substring(0, Math.min(migration.name.length, destination.length));
-  var destinationTest = destination.substring(0, Math.min(migration.name.length, destination.length));
-  return migrationTest <= destinationTest;
+var filesRegEx = /\.js$/;
+var coffeeSupported = false;
+var coffeeModule = null;
+try {
+  coffeeModule = require('coffee-script');
+  if (coffeeModule && coffeeModule.register) coffeeModule.register();
+  coffeeSupported = true;
+  filesRegEx = /\.(js|coffee)$/;
+} catch (e) {}
+
+function formatPath(dir, name) {
+  return path.join(dir, name);
 }
 
-function isIncludedInDown(migration, destination) {
-  if(!destination) {
-    return true;
-  }
-  var migrationTest = migration.name.substring(0, Math.min(migration.name.length, destination.length));
-  var destinationTest = destination.substring(0, Math.min(migration.name.length, destination.length));
-  return migrationTest >= destinationTest;
+function formatName(title, date) {
+  var name = formatTitle(title).split('/');
+  name[name.length - 1] = formatDate(date) + '-' + name[name.length -1];
+  return name.join('/');
 }
 
-function filterUp(allMigrations, completedMigrations, destination, count) {
-  var sortFn = function(a, b) {
-    return a.name.slice(0, a.name.indexOf('-')) - b.name.slice(0, b.name.indexOf('-'));
-  };
-
-  return allMigrations.sort(sortFn)
-  .filter(function(migration) {
-    var hasRun = completedMigrations.some(function(completedMigration) {
-      return completedMigration.name === migration.name;
-    });
-    return !hasRun;
-  })
-  .filter(function(migration) {
-    return isIncludedInUp(migration, destination);
-  })
-  .slice(0, count);
+function formatDate(date) {
+  return [
+    date.getUTCFullYear(),
+    lpad(date.getUTCMonth() + 1, '0', 2),
+    lpad(date.getUTCDate(), '0', 2),
+    lpad(date.getUTCHours(), '0', 2),
+    lpad(date.getUTCMinutes(), '0', 2),
+    lpad(date.getUTCSeconds(), '0', 2)
+  ].join('');
 }
 
-function filterDown(completedMigrations, destination, count) {
-  return completedMigrations
-  .filter(function(completedMigration) {
-    return isIncludedInDown(completedMigration, destination);
-  })
-  .slice(0, count);
+function formatTitle(title) {
+  return inflection.dasherize(title);
 }
 
+function parseDate(name) {
+  var date = new Date();
+  var match = name.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})-[^\.]+/);
+  date.setUTCFullYear(match[1]);
+  date.setUTCMonth(match[2] - 1);
+  date.setUTCDate(match[3]);
+  date.setUTCHours(match[4]);
+  date.setUTCMinutes(match[5]);
+  date.setUTCSeconds(match[6]);
+  return date;
+}
 
-Migrator = function(driver, migrationsDir) {
-  this.driver = driver;
-  this.migrationsDir = migrationsDir;
-};
+function parseTitle(name) {
+  var match = name.match(/\d{14}-([^\.]+)/);
+  var dashed = match[1];
+  return inflection.humanize(dashed, true);
+}
 
-Migrator.prototype = {
-  createMigrationTable: function(callback) {
-    this.driver.createMigrationTable(callback);
-  },
+function writeMigrationRecord(db, migration, callback) {
+  db._runSql('INSERT INTO migrations (name, run_on) VALUES (?, ?)', [migration.name, new Date()], callback);
+}
 
-  writeMigrationRecord: function(migration, callback) {
-    function onComplete(err) {
-      if (err) {
-        log.error(migration.name, err);
-      } else {
-        log.info('Processed migration', migration.name);
-      }
-      callback(err);
-    }
-    this.driver.addMigrationRecord(migration.name, onComplete);
-  },
+var migrationTemplate = [
+  "var lines = [",
+  "",
+  "];",
+  "",
+  "exports.up = function(db, callback) { var i = 0; lines.forEach(function(line){ db.runSql(line, function(err){ if (err) return callback(err); if (++i >= lines.length) callback(); }); }); };",
+  ""
+].join("\n");
 
-  deleteMigrationRecord: function(migration, callback) {
-    function onComplete(err) {
-      if (err) {
-        log.error(migration.name, err);
-      } else {
-        log.info('Processed migration', migration.name);
-      }
-      callback(err);
-    }
-    this.driver.runSql('DELETE FROM migrations WHERE name = ?', [migration.name], onComplete);
-  },
-
-  up: function(funcOrOpts, callback) {
-    if (dbmUtil.isFunction(funcOrOpts)) {
-      funcOrOpts(this.driver, callback);
-    } else {
-      this.upToBy(funcOrOpts.destination, funcOrOpts.count, callback);
-    }
-  },
-
-  down: function(funcOrOpts, callback) {
-    if (dbmUtil.isFunction(funcOrOpts)) {
-      funcOrOpts(this.driver, callback);
-    } else {
-      this.downToBy(funcOrOpts.destination, funcOrOpts.count, callback);
-    }
-  },
-
-  upBy: function(count, callback) {
-    this.upToBy('99999999999999', count, callback);
-  },
-
-  upTo: function(partialName, callback) {
-    this.upToBy(partialName, Number.MAX_VALUE, callback);
-  },
-
-  upToBy: function(partialName, count, callback) {
-    var self = this;
-    Migration.loadFromFilesystem(self.migrationsDir, function(err, allMigrations) {
-      if (err) { callback(err); return; }
-
-      Migration.loadFromDatabase(self.migrationsDir, self.driver, function(err, completedMigrations) {
-        if (err) { callback(err); return; }
-        var toRun = filterUp(allMigrations, completedMigrations, partialName, count);
-
-        if (toRun.length === 0) {
-          log.info('No migrations to run');
-          callback(null);
-          return;
-        }
-
-        async.forEachSeries(toRun, function(migration, next) {
-          log.verbose('preparing to run up migration:', migration.name);
-          self.driver.startMigration(function() {
-            self.up(migration.up.bind(migration), function(err) {
-              if (err) { callback(err); return; }
-              self.writeMigrationRecord(migration, function() { self.driver.endMigration(next); });
-            });
-          });
-        }, callback);
-      });
-    });
-  },
-
-  downBy: function(count, callback) {
-    this.downToBy('00000000000000', count, callback);
-  },
-
-  downTo: function(partialName, callback) {
-    this.downToBy(partialName, Number.MAX_VALUE, callback);
-  },
-
-  downToBy: function(partialName, count, callback) {
-    var self = this;
-    Migration.loadFromDatabase(self.migrationsDir, self.driver, function(err, completedMigrations) {
-      if (err) { return callback(err); }
-
-      var toRun = filterDown(completedMigrations, partialName, count);
-
-      if (toRun.length === 0) {
-        log.info('No migrations to run');
-        callback(null);
-        return;
-      }
-
-      async.forEachSeries(toRun, function(migration, next) {
-        log.verbose('preparing to run down migration:', migration.name);
-        self.down(migration.down.bind(migration), function(err) {
-          if (err) { callback(err); return; }
-          self.deleteMigrationRecord(migration, next);
-        });
-      }, callback);
-    });
+Migration = function() {
+  if (arguments.length == 3) {
+    this.title = arguments[0];
+    this.date = arguments[2];
+    this.name = formatName(this.title, this.date);
+    this.path = formatPath(arguments[1], this.name);
+  } else if (arguments.length == 2) {
+    this.path = arguments[0];
+    this.name = Migration.parseName(this.path, arguments[1]);
+    this.date = parseDate(this.name);
+    this.title = parseTitle(this.name);
   }
 };
 
-module.exports = Migrator;
+Migration.prototype._up = function() {
+  return require(this.path).up.apply(this, arguments);
+};
+
+Migration.prototype._down = function() {
+  return require(this.path).down.apply(this, arguments);
+};
+
+Migration.prototype.write = function(callback) {
+  fs.writeFile(this.path, migrationTemplate, callback);
+};
+
+Migration.prototype.up = function(db, callback) {
+  this._up(db, callback);
+};
+
+Migration.prototype.down = function(db, callback) {
+  this._down(db, callback);
+};
+
+Migration.parseName = function(path, dir) {
+  console.log(dir, path);
+  return path.replace(dir + '/', '').replace('.js', '');
+};
+
+Migration.loadFromFilesystem = function(dir, callback) {
+  log.verbose('loading migrations from dir', dir);
+  var walker = walk.walk(dir),
+      files = [];
+  walker.on('file', function(root, file, next){
+    files.push((root.replace(dir, '') + '/').substr(1) + file.name);
+    next();
+  });
+  walker.on('end', function(){
+    files.sort();
+    var coffeeWarn = true;
+    files = files.filter(function(file) {
+      if (coffeeWarn && !coffeeSupported && /\.coffee$/.test(file)) {
+        log.warn('CoffeeScript not installed');
+        coffeeWarn = false;
+      }
+      return filesRegEx.test(file);
+    });
+    var migrations = files.sort().map(function(file) {
+      return new Migration(path.join(dir, file), dir);
+    });
+
+    callback(null, migrations);
+  });
+};
+
+Migration.loadFromDatabase = function(dir, driver, callback) {
+  log.verbose('loading migrations from database');
+  driver.all('SELECT * FROM migrations ORDER BY name DESC', function(err, dbResults) {
+    if (err) { callback(err); return; }
+    var migrations = dbResults.map(function(result) {
+      return new Migration(path.join(dir, result.name));
+    });
+    callback(null, migrations);
+  });
+};
+
+module.exports = Migration;

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -1,151 +1,169 @@
-var fs = require('fs');
-var path = require('path');
-var walk = require('walk');
-var inflection = require('./inflection');
-var lpad = require('./util').lpad;
-var config = require('./config');
+var async = require('async');
+var dbmUtil = require('./util');
+var Migration = require('./migration');
 var log = require('./log');
 
-var filesRegEx = /\.js$/;
-var coffeeSupported = false;
-var coffeeModule = null;
-try {
-  coffeeModule = require('coffee-script');
-  if (coffeeModule && coffeeModule.register) coffeeModule.register();
-  coffeeSupported = true;
-  filesRegEx = /\.(js|coffee)$/;
-} catch (e) {}
-
-function formatPath(dir, name) {
-  return path.join(dir, name);
+function isIncludedInUp(migration, destination) {
+  if(!destination) {
+    return true;
+  }
+  var migrationTest = migration.name.substring(0, Math.min(migration.name.length, destination.length));
+  var destinationTest = destination.substring(0, Math.min(migration.name.length, destination.length));
+  return migrationTest <= destinationTest;
 }
 
-function formatName(title, date) {
-  var name = formatTitle(title).split('/');
-  name[name.length - 1] = formatDate(date) + '-' + name[name.length -1];
-  return name.join('/');
+function isIncludedInDown(migration, destination) {
+  if(!destination) {
+    return true;
+  }
+  var migrationTest = migration.name.substring(0, Math.min(migration.name.length, destination.length));
+  var destinationTest = destination.substring(0, Math.min(migration.name.length, destination.length));
+  return migrationTest >= destinationTest;
 }
 
-function formatDate(date) {
-  return [
-    date.getUTCFullYear(),
-    lpad(date.getUTCMonth() + 1, '0', 2),
-    lpad(date.getUTCDate(), '0', 2),
-    lpad(date.getUTCHours(), '0', 2),
-    lpad(date.getUTCMinutes(), '0', 2),
-    lpad(date.getUTCSeconds(), '0', 2)
-  ].join('');
+function filterUp(allMigrations, completedMigrations, destination, count) {
+  var sortFn = function(a, b) {
+    return a.name.slice(0, a.name.indexOf('-')) - b.name.slice(0, b.name.indexOf('-'));
+  };
+
+  return allMigrations.sort(sortFn)
+  .filter(function(migration) {
+    var hasRun = completedMigrations.some(function(completedMigration) {
+      return completedMigration.name === migration.name;
+    });
+    return !hasRun;
+  })
+  .filter(function(migration) {
+    return isIncludedInUp(migration, destination);
+  })
+  .slice(0, count);
 }
 
-function formatTitle(title) {
-  return inflection.dasherize(title);
+function filterDown(completedMigrations, destination, count) {
+  return completedMigrations
+  .filter(function(completedMigration) {
+    return isIncludedInDown(completedMigration, destination);
+  })
+  .slice(0, count);
 }
 
-function parseDate(name) {
-  var date = new Date();
-  var match = name.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})-[^\.]+/);
-  date.setUTCFullYear(match[1]);
-  date.setUTCMonth(match[2] - 1);
-  date.setUTCDate(match[3]);
-  date.setUTCHours(match[4]);
-  date.setUTCMinutes(match[5]);
-  date.setUTCSeconds(match[6]);
-  return date;
-}
 
-function parseTitle(name) {
-  var match = name.match(/\d{14}-([^\.]+)/);
-  var dashed = match[1];
-  return inflection.humanize(dashed, true);
-}
+Migrator = function(driver, migrationsDir) {
+  this.driver = driver;
+  this.migrationsDir = migrationsDir;
+};
 
-function writeMigrationRecord(db, migration, callback) {
-  db._runSql('INSERT INTO migrations (name, run_on) VALUES (?, ?)', [migration.name, new Date()], callback);
-}
+Migrator.prototype = {
+  createMigrationTable: function(callback) {
+    this.driver.createMigrationTable(callback);
+  },
 
-var migrationTemplate = [
-  "var lines = [",
-  "",
-  "];",
-  "",
-  "exports.up = function(db, callback) { var i = 0; lines.forEach(function(line){ db.runSql(line, function(err){ if (err) return callback(err); if (++i >= lines.length) callback(); }); }); };",
-  ""
-].join("\n");
+  writeMigrationRecord: function(migration, callback) {
+    function onComplete(err) {
+      if (err) {
+        log.error(migration.name, err);
+      } else {
+        log.info('Processed migration', migration.name);
+      }
+      callback(err);
+    }
+    this.driver.addMigrationRecord(migration.name, onComplete);
+  },
 
-Migration = function() {
-  if (arguments.length == 3) {
-    this.title = arguments[0];
-    this.date = arguments[2];
-    this.name = formatName(this.title, this.date);
-    this.path = formatPath(arguments[1], this.name);
-  } else if (arguments.length == 2) {
-    this.path = arguments[0];
-    this.name = Migration.parseName(this.path, arguments[1]);
-    this.date = parseDate(this.name);
-    this.title = parseTitle(this.name);
+  deleteMigrationRecord: function(migration, callback) {
+    function onComplete(err) {
+      if (err) {
+        log.error(migration.name, err);
+      } else {
+        log.info('Processed migration', migration.name);
+      }
+      callback(err);
+    }
+    this.driver.runSql('DELETE FROM migrations WHERE name = ?', [migration.name], onComplete);
+  },
+
+  up: function(funcOrOpts, callback) {
+    if (dbmUtil.isFunction(funcOrOpts)) {
+      funcOrOpts(this.driver, callback);
+    } else {
+      this.upToBy(funcOrOpts.destination, funcOrOpts.count, callback);
+    }
+  },
+
+  down: function(funcOrOpts, callback) {
+    if (dbmUtil.isFunction(funcOrOpts)) {
+      funcOrOpts(this.driver, callback);
+    } else {
+      this.downToBy(funcOrOpts.destination, funcOrOpts.count, callback);
+    }
+  },
+
+  upBy: function(count, callback) {
+    this.upToBy('99999999999999', count, callback);
+  },
+
+  upTo: function(partialName, callback) {
+    this.upToBy(partialName, Number.MAX_VALUE, callback);
+  },
+
+  upToBy: function(partialName, count, callback) {
+    var self = this;
+    Migration.loadFromFilesystem(self.migrationsDir, function(err, allMigrations) {
+      if (err) { callback(err); return; }
+
+      Migration.loadFromDatabase(self.migrationsDir, self.driver, function(err, completedMigrations) {
+        if (err) { callback(err); return; }
+        var toRun = filterUp(allMigrations, completedMigrations, partialName, count);
+
+        if (toRun.length === 0) {
+          log.info('No migrations to run');
+          callback(null);
+          return;
+        }
+
+        async.forEachSeries(toRun, function(migration, next) {
+          log.verbose('preparing to run up migration:', migration.name);
+          self.driver.startMigration(function() {
+            self.up(migration.up.bind(migration), function(err) {
+              if (err) { callback(err); return; }
+              self.writeMigrationRecord(migration, function() { self.driver.endMigration(next); });
+            });
+          });
+        }, callback);
+      });
+    });
+  },
+
+  downBy: function(count, callback) {
+    this.downToBy('00000000000000', count, callback);
+  },
+
+  downTo: function(partialName, callback) {
+    this.downToBy(partialName, Number.MAX_VALUE, callback);
+  },
+
+  downToBy: function(partialName, count, callback) {
+    var self = this;
+    Migration.loadFromDatabase(self.migrationsDir, self.driver, function(err, completedMigrations) {
+      if (err) { return callback(err); }
+
+      var toRun = filterDown(completedMigrations, partialName, count);
+
+      if (toRun.length === 0) {
+        log.info('No migrations to run');
+        callback(null);
+        return;
+      }
+
+      async.forEachSeries(toRun, function(migration, next) {
+        log.verbose('preparing to run down migration:', migration.name);
+        self.down(migration.down.bind(migration), function(err) {
+          if (err) { callback(err); return; }
+          self.deleteMigrationRecord(migration, next);
+        });
+      }, callback);
+    });
   }
 };
 
-Migration.prototype._up = function() {
-  return require(this.path).up.apply(this, arguments);
-};
-
-Migration.prototype._down = function() {
-  return require(this.path).down.apply(this, arguments);
-};
-
-Migration.prototype.write = function(callback) {
-  fs.writeFile(this.path, migrationTemplate, callback);
-};
-
-Migration.prototype.up = function(db, callback) {
-  this._up(db, callback);
-};
-
-Migration.prototype.down = function(db, callback) {
-  this._down(db, callback);
-};
-
-Migration.parseName = function(path, dir) {
-  console.log(dir, path);
-  return path.replace(dir + '/', '').replace('.js', '');
-};
-
-Migration.loadFromFilesystem = function(dir, callback) {
-  log.verbose('loading migrations from dir', dir);
-  var walker = walk.walk(dir),
-      files = [];
-  walker.on('file', function(root, file, next){
-    files.push((root.replace(dir, '') + '/').substr(1) + file.name);
-    next();
-  });
-  walker.on('end', function(){
-    files.sort();
-    var coffeeWarn = true;
-    files = files.filter(function(file) {
-      if (coffeeWarn && !coffeeSupported && /\.coffee$/.test(file)) {
-        log.warn('CoffeeScript not installed');
-        coffeeWarn = false;
-      }
-      return filesRegEx.test(file);
-    });
-    var migrations = files.sort().map(function(file) {
-      return new Migration(path.join(dir, file), dir);
-    });
-
-    callback(null, migrations);
-  });
-};
-
-Migration.loadFromDatabase = function(dir, driver, callback) {
-  log.verbose('loading migrations from database');
-  driver.all('SELECT * FROM migrations ORDER BY name DESC', function(err, dbResults) {
-    if (err) { callback(err); return; }
-    var migrations = dbResults.map(function(result) {
-      return new Migration(path.join(dir, result.name), dir);
-    });
-    callback(null, migrations);
-  });
-};
-
-module.exports = Migration;
+module.exports = Migrator;

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -23,7 +23,7 @@ function isIncludedInDown(migration, destination) {
 
 function filterUp(allMigrations, completedMigrations, destination, count) {
   var sortFn = function(a, b) {
-    return a.name.slice(0, a.name.indexOf('-')) - b.name.slice(0, b.name.indexOf('-'));
+    return a.name.localeCompare(b.name);
   };
 
   return allMigrations.sort(sortFn)

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -142,7 +142,7 @@ Migration.loadFromDatabase = function(dir, driver, callback) {
   driver.all('SELECT * FROM migrations ORDER BY name DESC', function(err, dbResults) {
     if (err) { callback(err); return; }
     var migrations = dbResults.map(function(result) {
-      return new Migration(path.join(dir, result.name));
+      return new Migration(path.join(dir, result.name), dir);
     });
     callback(null, migrations);
   });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "~1.7.2",
     "pkginfo": "~0.3.0",
     "parse-database-url": "~0.2.0",
-    "walk": "~2.3.1",
+    "walk": "~2.3.1"
   },
   "devDependencies": {
     "vows": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "mkdirp": "~0.3.4",
     "moment": "~1.7.2",
     "pkginfo": "~0.3.0",
-    "parse-database-url": "~0.2.0"
+    "parse-database-url": "~0.2.0",
+    "walk": "~2.3.1",
   },
   "devDependencies": {
     "vows": "~0.7.0",


### PR DESCRIPTION
We were starting to get a lot of files in our migrations dir, so we created a way to use folders in the migrations directory.

You can now organize your files like so:
```
<migrations-dir>/20140327123829-root-folder.js
<migrations-dir>/v1.0.0/20140327123829-test.js
<migrations-dir>/v1.1.0/20140327123829-test.js
```

Doing `db-migrate create v1.0.0/test` would result in a file created at `<migrations-dir>/v1.0.0/20140327123829-test.js`.

Running the script will make an entry in the migrations table for `v1.0.0/20140327123829-test`.

No support provided, if you have a need for it, feel free to use it. No tests were created for it, didn't have time to create any.