### PR TITLE
use .env file for DATABASE_URL if present

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -10,6 +10,9 @@ var config = require('../lib/config.js');
 var index = require('../index');
 var log = require('../lib/log');
 var pkginfo = require('pkginfo')(module, 'version');
+var dotenv = require('dotenv');
+
+dotenv.load();
 
 process.on('uncaughtException', function(err) {
   log.error(err.stack);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "mkdirp": "~0.3.4",
     "moment": "~1.7.2",
     "pkginfo": "~0.3.0",
-    "parse-database-url": "~0.2.0"
+    "parse-database-url": "~0.2.0",
+    "dotenv": "^0.2.8"
   },
   "devDependencies": {
     "vows": "~0.7.0",


### PR DESCRIPTION
This uses the `dotenv` module to read environment variables from a `.env`, if present, allowing the user to specify the database creds via this file locally.

This simplifies e.g. writing apps that get deployed to Heroku and use db-migrate.
- My server code can always depend on having the DATABASE_URL environment variable set. Locally via `.env` file, and in production set on the server
- db-migrate will work in both environments cleanly this way
- I don't have to code my server to be aware of the database.json file or ensure that files are there locally / in production.

In short, i feel using this makes handling different environments a little more clean.

I dont have tests as I dont have mysql running locally but could drop some in if you have some suggestions.
