### PR TITLE
JSON.strigify on non string objects

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -179,6 +179,10 @@ var PgDriver = Base.extend({
         return (columnName.charAt(0) != '"') ? '"' + columnName + '"' : columnName;
       });
 
+      valueArray = valueArray.map(function(value) {
+        return 'string' === typeof value ? value : JSON.stringify(value);
+      });
+
       return this._super(tableName, columnNameArray, valueArray, callback);
     },
 


### PR DESCRIPTION
non string objects are easily converted to strings.
this is cool if you have json or jsonb data column

quick esample:  

``` javascript
    db.insert( 'pages',
        [
            'url',
            'title',
            'components',                    // jsonb column
            'created_at',
            'updated_at'
        ],
        [
            '/',
            'Home Page',
            ['a','custom','array'],         // previously it had to be JSON.stringify(['a','custom','array'])
            'now()',
            'now()'
        ],
        callback
    );
```
