### PR TITLE
Added support for 'postgresql' driver in DATABASE_URL

### DIFF
--- a/lib/driver/postgresql.js
+++ b/lib/driver/postgresql.js
@@ -1,0 +1,1 @@
+module.exports = require('./pg');


### PR DESCRIPTION
I want to use db-migrate on OpenShift. But OpenShift exports DB connect string in environment variable OPENSHIFT_POSTGRESQL_DB_URL in format `postgresql://user:password@127.8.244.130:5432` and db-migrate fails - it can not find driver for postgresql. I think 'postgresql' is reasonable name for a driver and should be supported.
