### PR TITLE
Added back quotes around foreign key name

### DIFF
--- a/lib/driver/mysql.js
+++ b/lib/driver/mysql.js
@@ -243,7 +243,7 @@ var MysqlDriver = Base.extend({
     }
     var columns = Object.keys(fieldMapping);
     var referencedColumns = columns.map(function (key) { return fieldMapping[key]; });
-    var sql = util.format('ALTER TABLE `%s` ADD CONSTRAINT `%s` FOREIGN KEY (%s) REFERENCES `%s` (%s) ON DELETE %s ON UPDATE %s',
+    var sql = util.format('ALTER TABLE `%s` ADD CONSTRAINT `%s` FOREIGN KEY (`%s`) REFERENCES `%s` (%s) ON DELETE %s ON UPDATE %s',
       tableName, keyName, columns, referencedTableName, referencedColumns, rules.onDelete || 'NO ACTION', rules.onUpdate || 'NO ACTION');
     this.runSql(sql, callback);
   },


### PR DESCRIPTION
This eliminates problems with key fields named like reserved word ("grant" in my case)
