### PR TITLE
Add ability to migrate with promises.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var Migrator = require('./lib/migrator');
 
 exports.dataType = require('./lib/data_type');
 exports.config = require('./lib/config');
+exports.Promise = require('bluebird');
 
 exports.connect = function(config, callback) {
   driver.connect(config, function(err, db) {

--- a/lib/driver/index.js
+++ b/lib/driver/index.js
@@ -8,6 +8,7 @@ exports.connect = function(config, callback) {
   var req = './' + config.driver;
   log.verbose('require:', req);
   var driver = require(req);
+
   log.verbose('connecting');
   driver.connect(config, function(err, db) {
     if (err) { callback(err); return; }

--- a/lib/driver/mysql.js
+++ b/lib/driver/mysql.js
@@ -3,6 +3,7 @@ var moment = require('moment');
 var mysql = require('mysql');
 var Base = require('./base');
 var type = require('../data_type');
+var Promise = require('bluebird');
 var log = require('../log');
 
 var MysqlDriver = Base.extend({
@@ -290,6 +291,8 @@ var MysqlDriver = Base.extend({
   }
 
 });
+
+Promise.promisifyAll(MysqlDriver.prototype);
 
 exports.connect = function(config, callback) {
   var db;

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -3,6 +3,7 @@ var pg = require('pg');
 var semver = require('semver');
 var Base = require('./base');
 var type = require('../data_type');
+var Promise = require('bluebird');
 var log = require('../log');
 
 var PgDriver = Base.extend({
@@ -218,6 +219,8 @@ var PgDriver = Base.extend({
     }
 
 });
+
+Promise.promisifyAll(PgDriver.prototype);
 
 exports.connect = function(config, callback) {
     if (config.native) { pg = pg.native; }

--- a/lib/driver/sqlite3.js
+++ b/lib/driver/sqlite3.js
@@ -3,6 +3,7 @@ var sqlite3 = require('sqlite3').verbose();
 var Base = require('./base');
 var log = require('../log');
 var type = require('../data_type');
+var Promise = require('bluebird');
 
 var defaultMode = sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE;
 
@@ -81,6 +82,8 @@ var Sqlite3Driver = Base.extend({
   }
 
 });
+
+Promise.promisifyAll(Sqlite3Driver.prototype);
 
 exports.connect = function(config, callback) {
   var mode = config.mode || defaultMode;

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -4,6 +4,7 @@ var inflection = require('./inflection');
 var lpad = require('./util').lpad;
 var config = require('./config');
 var log = require('./log');
+var Promise = require('bluebird');
 
 var filesRegEx = /\.js$/;
 var coffeeSupported = false;
@@ -101,11 +102,17 @@ Migration.prototype.write = function(callback) {
 };
 
 Migration.prototype.up = function(db, callback) {
-  this._up(db, callback);
+  var val = this._up(db, callback);
+  if (val instanceof Promise) {
+    val.nodeify(callback);
+  }
 };
 
 Migration.prototype.down = function(db, callback) {
-  this._down(db, callback);
+  var val = this._down(db, callback);
+  if (val instanceof Promise) {
+    val.nodeify(callback);
+  }
 };
 
 Migration.parseName = function(path) {

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
     "url": "https://github.com/kunklejr/node-db-migrate.git"
   },
   "dependencies": {
-    "optimist": "~0.3.0",
     "async": "~0.1.15",
-    "semver": "~1.0.14",
+    "bluebird": "~2.3.10",
+    "dotenv": "~0.2.8",
     "mkdirp": "~0.3.4",
     "moment": "~1.7.2",
-    "pkginfo": "~0.3.0",
+    "optimist": "~0.3.0",
     "parse-database-url": "~0.2.0",
-    "dotenv": "~0.2.8"
+    "pkginfo": "~0.3.0",
+    "semver": "~1.0.14"
   },
   "devDependencies": {
     "vows": "~0.7.0",


### PR DESCRIPTION
These changes enable the use of promises in migrations. For example, the following:

```js
var async = require('async');

exports.up = function (db, callback) {
  async.series([
    db.createTable.bind(db, 'pets', {
      id: { type: 'int', primaryKey: true },
      name: 'string'
    }),
    db.createTable.bind(db, 'owners', {
      id: { type: 'int', primaryKey: true },
      name: 'string'
    });
  ], callback);
};

exports.down = function (db, callback) {
  async.series([
    db.dropTable.bind(db, 'pets'),
    db.dropTable.bind(db, 'owners')
  ], callback);
};
```

Can be turned into the following:

```js
exports.up = function (db, callback) {
  return db.createTableAsync('pets', {
    id: {type: 'int', primaryKey: true },
    name: 'string'
  }).then(function () {
    return db.createTableAsync('owners', {
      id: { type: 'int', primaryKey: true },
      name: 'string'
    });
  });
};

exports.down = function (db, callback) {
  return db.dropTableAsync('pets').then(function () {
    return db.dropTableAsync('owners');
  });
};
```

Imagine chaining like crazy:

```js
exports.down = function (db, callback) {
  return db.dropTableAsync('pets').then(function () {
    return db.dropTableAsync('owners');
  }).then(function () {
    return db.dropTableAsync('third');
  }).then(function () {
    return db.dropTableAsync('fourth');
  }).then(function () {
    return db.dropTableAsync('fifth');
  });
};
```

The real benefit is how much control-flow stuff we gain from Bluebird without having to include any additional libraries (everything is built in to the promises): https://github.com/petkaantonov/bluebird/blob/master/API.md

Just for reference, this will improve even more with ES6:

```js
exports.down = function (db, callback) {
  return db.dropTable('pets').then(() => db.dropTable('owners'));
};
```

Something similar is currently possible with LoDash:

```js
exports.down = function (db, callback) {
  return db.dropTable('pets').then(_.bindKey(db, 'dropTable', 'owners'));
};
```

The Bluebird `Promise` constructor is exported on `index`:

```js
var Promise = require('db-migrate').Promise;
```

What still needs to be done:

* Documentation
* Tests
* Update migration template to get a reference to `Promise` (optional)
* Feedback