### PR TITLE
masked passwords in verbose log

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -96,7 +96,12 @@ function loadConfig() {
   }
   if(verbose) {
     var current = config.getCurrent();
-    log.info('Using', current.env, 'settings:', current.settings);
+    var s = JSON.parse(JSON.stringify(current.settings));
+
+    if (s["password"])
+      s["password"] = "******";
+    
+    log.info('Using', current.env, 'settings:', s);
   }
 }
 


### PR DESCRIPTION
Didn't like, when passwords are in logs. Now "password" config field is masked when flushed to logs.
