### PR TITLE
Fix typo

### DIFF
--- a/lib/driver/index.js
+++ b/lib/driver/index.js
@@ -2,7 +2,7 @@ var log = require('../log');
 
 exports.connect = function(config, callback) {
   if (config.driver === undefined) {
-    throw new Error('config must include a driver key specifing which driver to use');
+    throw new Error('config must include a driver key specifying which driver to use');
   }
 
   var req = './' + config.driver;


### PR DESCRIPTION
Changed "specifing" to "specifying" in missing config driver parameter error message.
