### PR TITLE
Add support for connecting to the database through an SSH tunnel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,32 @@ It's currently also not possible to switch the database over this config with **
   "schema": "test"
 }
 ```
+
+## Connecting through an SSH tunnel
+
+If you need to connect to the database through an SSH tunnel, you can set the `tunnel` config:
+
+```json
+{
+  "tunnel": {
+    "localPort" : 33333,
+    "host": "ssh-machine.example.com",
+    "username": "sshuser",
+    "privateKeyPath": "/home/sshuser/privatekey.pem"
+  }
+}
+```
+
+One common use case for this is when the remote DB does not accept connections from the host that will be running db-migrate. For example, a database within an AWS
+[Virtual Private Cloud (VPC)](http://aws.amazon.com/vpc) that is only open to [EC2](http://aws.amazon.com/ec2) hosts within the same VPC. By pointing the tunnel sshConfig to a host within the DB's
+VPC, you can run your migrations from any host.
+
+### Tunnel configuration properties
+
+The `tunnel` config must specify the `localPort` in addition to any configuration necessary to connect to the SSH tunnel. Please see the [https://github.com/Finanzchef24-GmbH/tunnel-ssh](tunnel-ssh)
+documentation for more details about what properties to set on the tunnel config. The only addition to that config is the `privateKeyPath` property. If the connection to your SSH host
+requires a private key file, you can specify its path using this property.
+
 ## Defaults
 
 ## Generic Datatypes

--- a/lib/driver/index.js
+++ b/lib/driver/index.js
@@ -6,7 +6,7 @@ internals.mod.type = require('../data_type');
 internals.mod.Class = require('../class');
 var Shadow = require('./shadow');
 var log = internals.mod.log;
-
+var tunnel = require('tunnel-ssh');
 
 exports.connect = function (config, intern, callback) {
   var driver, req;
@@ -51,18 +51,49 @@ exports.connect = function (config, intern, callback) {
   }
 
   log.verbose('connecting');
-  driver.connect(config, intern, function (err, db) {
 
-    if (err) {
+  var connect = function(config) {
+    driver.connect(config, intern, function (err, db) {
 
-      callback(err);
-      return;
+      if (err) {
+
+        callback(err);
+        return;
+      }
+      log.verbose('connected');
+
+      if (!global.immunity)
+        db = Shadow.infect(db);
+
+      callback(null, db);
+    });
+  };
+
+  if (config.tunnel) {
+    var tunnelConfig = JSON.parse(JSON.stringify(config.tunnel));
+    tunnelConfig.dstHost = config.host;
+    tunnelConfig.dstPort = config.port;
+
+    if (tunnelConfig.privateKeyPath) {
+      tunnelConfig.privateKey = require('fs').readFileSync(tunnelConfig.privateKeyPath);
     }
-    log.verbose('connected');
 
-    if(!global.immunity)
-      db = Shadow.infect(db);
+    // Reassign the db host/port to point to our local ssh tunnel
+    config.host = '127.0.0.1';
+    config.port = tunnelConfig.localPort;
 
-    callback(null, db);
-  });
+    tunnel(tunnelConfig, function (err) {
+
+      if (err) {
+        callback(err);
+        return;
+      }
+      log.verbose('SSH tunnel connected on port ', tunnelConfig.localPort);
+
+      connect(config);
+    });
+  }
+  else {
+    connect(config);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -38,13 +38,16 @@
     "pg-native": "^1.8.0",
     "pkginfo": "~0.3.0",
     "semver": "~4.3.0",
-    "sqlite3": "~3.0.4"
+    "sqlite3": "~3.0.4",
+    "tunnel-ssh": "^1.0.0"
   },
   "devDependencies": {
     "code": "^1.3.0",
     "db-meta": "~0.4.1",
     "lab": "^5.2.1",
+    "proxyquire": "^1.4.0",
     "rimraf": "~2.3.2",
+    "sinon": "^1.14.1",
     "vows": "0.8.0"
   },
   "scripts": {

--- a/test/driver/index_test.js
+++ b/test/driver/index_test.js
@@ -1,0 +1,104 @@
+var vows = require('vows');
+var assert = require('assert');
+var proxyquire = require('proxyquire');
+var sinon = require('sinon');
+
+var validDbConfigWithTunnel = {
+  driver: 'mysql',
+  host: 'dbHost',
+  port: 'dbPort',
+  tunnel: {
+    localPort: 'localPort',
+    host: 'sshHost',
+    port: 'sshPort'
+  }
+};
+
+var indexConnectCallback = function(self, tunnelStub, driverSpy) {
+  return function(err, db) {
+    if (err) {
+      self.callback(err, db, tunnelStub, driverSpy);
+      return;
+    }
+    db.close(function() {
+      self.callback(err, db, tunnelStub, driverSpy);
+    });
+  }
+};
+
+vows.describe('index').addBatch({
+  'a connection with ssh tunnel': {
+    topic: function() {
+      // Ensure that require gets a new copy of the module for each test
+      delete require.cache[require.resolve('../../lib/driver/mysql')];
+      var driver = require('../../lib/driver/mysql');
+
+      // Set up stubs/spies to verify correct flow
+      var driverSpy = sinon.spy(driver, 'connect');
+      var tunnelStub = sinon.stub().callsArg(1);
+
+      var index = proxyquire('../../lib/driver/index', {
+        'tunnel-ssh': tunnelStub,
+        './mysql': driver
+      });
+
+      index.connect(validDbConfigWithTunnel, {}, indexConnectCallback(this, tunnelStub, driverSpy));
+    },
+    'should call tunnel once with db config properties added': function(err, db, tunnelStub) {
+      var expectedTunnelConfig = {
+        localPort: 'localPort',
+        host: 'sshHost',
+        port: 'sshPort',
+        dstHost: 'dbHost',
+        dstPort: 'dbPort'
+      };
+
+      assert.isNull(err);
+      assert.isNotNull(db);
+      assert(tunnelStub.withArgs(expectedTunnelConfig).calledOnce);
+    },
+    'should replace the db host and port with localhost and the tunnel localPort': function(err, db, tunnelStub, driverSpy) {
+      var expectedDbConfig = {
+        driver: 'mysql',
+        host: '127.0.0.1',
+        port: 'localPort',
+        tunnel: {
+          localPort: 'localPort',
+          host: 'sshHost',
+          port: 'sshPort'
+        }
+      };
+
+      assert(driverSpy.withArgs(expectedDbConfig).calledOnce);
+    },
+    teardown: function(db, tunnelStub, driverSpy) {
+      driverSpy.restore();
+    }
+  },
+  'a failed tunnel connection': {
+    topic: function() {
+      // Ensure that require gets a new copy of the module for each test
+      delete require.cache[require.resolve('../../lib/driver/mysql')];
+      var driver = require('../../lib/driver/mysql');
+
+      // Set up stubs/spies to verify correct flow
+      var tunnelStub = sinon.stub().callsArgWith(1, new Error("error"));
+      var driverSpy = sinon.spy(driver, 'connect');
+
+      var index = proxyquire('../../lib/driver/index', {
+        'tunnel-ssh': tunnelStub,
+        './mysql': driver
+      });
+
+      index.connect(validDbConfigWithTunnel, {}, indexConnectCallback(this, tunnelStub, driverSpy));
+    },
+    'should pass the error to the callback': function (err, db) {
+      assert(err, "err should be non-null");
+      assert(!db, "driver should be null or undefined");
+    },
+    'should call tunnel, but not driver.connect': function (err, db, tunnelStub, driverSpy) {
+      assert(tunnelStub.calledOnce, "tunnel should be called once");
+      assert(driverSpy.notCalled, "driver.connect should not be called");
+    }
+  }
+}).export(module);


### PR DESCRIPTION
This PR adds implementation, tests, and documentation to support making the DB connection through an SSH tunnel.  One fairly common use case is a database hosted as an Amazon RDS instance inside a Virtual Private Cloud (VPC).  These instances are only accessible from hosts within that same VPC.  If your application uses any external CI tool such as CircleCI, Travis, or Codeship (in my case), your pre-deployment build steps will be run from a host outside your VPC, making it impossible to run your db migrations this way.  By making use of an SSH tunnel, your db migrations can tunnel through a host within the VPC, allowing them to run anywhere while maintaining the security benefits of the VPC.