### PR TITLE
Change position of force-exit call

### DIFF
--- a/api.js
+++ b/api.js
@@ -266,10 +266,6 @@ dbmigrate.prototype = {
 
     run();
 
-    if (internals.argv['force-exit']) {
-      log.verbose('Forcing exit');
-      process.exit(0);
-    }
   }
 
 };
@@ -588,6 +584,11 @@ function onComplete(migrator, originalErr) {
     assert.ifError(originalErr);
     assert.ifError(err);
     log.info('Done');
+
+    if (internals.argv['force-exit']) {
+      log.verbose('Forcing exit');
+      process.exit(0);
+    }
   });
 }
 


### PR DESCRIPTION
When I use mongodb, the force-exit does not works then the force-exit is forced before execute my migrations.

I believe that the force-exit should be after log.info('Done') to resolve this, and this fixed my problem with mongodb.