### PR TITLE
Escape schema for postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ database.json
 Seeder
 VCSeeder
 archive
+
+# Vim swap files
+.*.sw[a-z]

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -158,7 +158,7 @@ var PgDriver = Base.extend({
             if (this.schema === 'public') {
                 searchPath = result[0].search_path;
             } else {
-                searchPath = this.schema + ',' + result[0].search_path;
+                searchPath = '"' + this.schema + '",' + result[0].search_path;
             }
 
             this.all('SET search_path TO ' + searchPath, function() {

--- a/test/driver/pg_schema_test.js
+++ b/test/driver/pg_schema_test.js
@@ -10,39 +10,52 @@ var client = new pg.Client('postgres://localhost/db_migrate_test');
 global.migrationTable = 'migrations';
 
 vows.describe('pg').addBatch({
-    'create schema and connect': {
-        topic: function() {
+    'connect to database': {
+        topic: function () {
             var callback = this.callback;
 
-            client.connect(function(err) {
+            client.connect(function (err) {
+                callback(err, client);
+            });
+        },
+
+        teardown: function () {
+          client.end();
+          this.callback();
+        },
+
+        'create schema and connect': {
+            topic: function() {
+                var callback = this.callback;
+
                 client.query('CREATE SCHEMA test_schema', function(err) {
                     driver.connect({ driver: 'pg', database: 'db_migrate_test', schema: 'test_schema' }, function(err, db) {
                         callback(null, db);
                     });
                 });
-            });
-        },
-
-        'migrations table': {
-            topic: function(db) {
-                var callback = this.callback;
-
-                db.createMigrationsTable(function() {
-                    client.query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'test_schema' AND table_name = 'migrations'", function(err, result) {
-                        callback(err, result);
-                    });
-                });
             },
 
-            'is in test_schema': function(err, result) {
-                assert.isNull(err);
-                assert.isNotNull(result);
-                assert.equal(result.rowCount, 1);
-            }
-        },
+            'migrations table': {
+                topic: function(db) {
+                    var callback = this.callback;
 
-        teardown: function() {
-            client.query('DROP SCHEMA test_schema CASCADE', this.callback);
+                    db.createMigrationsTable(function() {
+                        client.query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'test_schema' AND table_name = 'migrations'", function(err, result) {
+                            callback(err, result);
+                        });
+                    });
+                },
+
+                'is in test_schema': function(err, result) {
+                    assert.isNull(err);
+                    assert.isNotNull(result);
+                    assert.equal(result.rowCount, 1);
+                }
+            },
+
+            teardown: function() {
+                client.query('DROP SCHEMA test_schema CASCADE', this.callback);
+            }
         }
     }
 }).export(module);


### PR DESCRIPTION
If the name chosen for a schema contains certain characters, it must be
surrounded in quotes. This ensures those quotes are added when choosing the
schema by setting the `search_path`.