### PR TITLE
Advise to set multipleStatements in DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ If you use MySQL, to be able to use multiple statements in your sql file, you ha
 }
 ```
 
+You can also place it as a query string parameter into DATABASE_URL variable, as https://github.com/pwnall/node-parse-database-url allows passing them into config:
+
+    $ DATABASE_URL="mysql://DB_USER:DB_PASS@localhost/database-name?multipleStatements=true" db-migrate up
+
 ## Running Migrations
 
 When first running the migrations, all will be executed in sequence. A table named `migrations` will also be created in your database to track which migrations have been applied.


### PR DESCRIPTION
I've spent quite a bunch of time crawling the web for solution how to pass multipleStatements=true to db-migrated within automated process (grunt-db-migrate).