### PR TITLE
Added 'use strict' instructions at the beginning of generated JS files

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -44,6 +44,8 @@ var Migration = Skeleton.extend({
 
 Migration.prototype.defaultCoffeeTemplate = function() {
   return [
+    "'use strict';",
+    "",
     "dbm = undefined",
     "type = undefined",
     "",
@@ -64,6 +66,8 @@ Migration.prototype.defaultCoffeeTemplate = function() {
 
 Migration.prototype.defaultJsTemplate = function() {
   return [
+    "'use strict';",
+    "",
     "var dbm;",
     "var type;",
     "",
@@ -94,6 +98,8 @@ Migration.prototype.defaultSqlTemplate = function() {
 
 Migration.prototype.sqlFileLoaderTemplate = function() {
   return [
+    "'use strict';",
+    "",
     "var dbm;",
     "var type;",
     "var fs = require('fs');",
@@ -139,6 +145,8 @@ Migration.prototype.sqlFileLoaderTemplate = function() {
 
 Migration.prototype.coffeeSqlFileLoaderTemplate = function() {
   return [
+    "'use strict';",
+    "",
     "dbm = undefined",
     "type = undefined",
     "fs = require 'fs'",


### PR DESCRIPTION
For those who use a Javascript linter such as JSHint (with `"globalstrict": true`), this will avoid highlighting dozens of errors in the generated JS files.