### PR TITLE
Make the pg driver compatible with PostgreSQL 9.5alpha1

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -170,7 +170,7 @@ var PgDriver = Base.extend({
 
           for (var i = 0; i < search_pathes.length; ++i) {
             if (search_pathes[i].indexOf('"') !== 0) {
-              search_pathes[i] = '"' + search_pathes[i] + '"';
+              search_pathes[i] = '"' + search_pathes[i].trim() + '"';
             }
           }
 
@@ -180,9 +180,6 @@ var PgDriver = Base.extend({
           // search path. This will make all DDL/DML/SQL operate on the specified
           // schema.
           if (this.schema === 'public') {
-              console.log('inside if branch');
-              console.log(result);
-              console.log(result[0]);
               searchPath = result[0].search_path;
           } else {
               searchPath = '"' + this.schema + '",' + result[0].search_path;

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -181,9 +181,10 @@ var PgDriver = Base.extend({
           // schema.
           if (this.schema === 'public') {
               console.log('inside if branch');
+              console.log(result);
+              console.log(result[0]);
               searchPath = result[0].search_path;
           } else {
-              console.log('inside else branch');
               searchPath = '"' + this.schema + '",' + result[0].search_path;
           }
           console.log('searchPath: %s', searchPath);

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -184,7 +184,6 @@ var PgDriver = Base.extend({
           } else {
               searchPath = '"' + this.schema + '",' + result[0].search_path;
           }
-          console.log('searchPath: %s', searchPath);
 
           return this.all('SET search_path TO ' + searchPath);
         }.bind(this))

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -180,10 +180,13 @@ var PgDriver = Base.extend({
           // search path. This will make all DDL/DML/SQL operate on the specified
           // schema.
           if (this.schema === 'public') {
+              console.log('inside if branch');
               searchPath = result[0].search_path;
           } else {
+              console.log('inside else branch');
               searchPath = '"' + this.schema + '",' + result[0].search_path;
           }
+          console.log('searchPath: %s', searchPath);
 
           return this.all('SET search_path TO ' + searchPath);
         }.bind(this))


### PR DESCRIPTION
For some weird reason, pg 9.5 alpha 1 adds a space before the name of the schema in the command `SHOW search_path` which caused an error when running migrations. I added a `trim()` call on the string and it works now.