### PR TITLE
Added index length support for MySQL

### DIFF
--- a/lib/driver/mysql.js
+++ b/lib/driver/mysql.js
@@ -296,7 +296,26 @@ var MysqlDriver = Base.extend({
     if (!Array.isArray(columns)) {
       columns = [columns];
     }
-    var sql = util.format('ALTER TABLE `%s` ADD %s INDEX `%s` (`%s`)', tableName, (unique ? 'UNIQUE ' : ''), indexName, columns.join('`, `'));
+
+    var columnsList = [];
+    for (var columnIndex in columns) {
+      var column = columns[columnIndex];
+      var columnSpec = '';
+
+      if (typeof(column) === 'object' && column.name) {
+        columnSpec = util.format('`%s`%s',
+                column.name,
+                (column.length ? util.format('(%s)', parseInt(column.length)) : '')
+        );
+      } else if (typeof(column) === 'string') {
+        columnSpec = util.format('`%s`', column);
+      } else
+        return callback(new Error('Invalid column specification'));
+
+      columnsList.push(columnSpec);
+    }
+
+    var sql = util.format('ALTER TABLE `%s` ADD %s INDEX `%s` (%s)', tableName, (unique ? 'UNIQUE ' : ''), indexName, columnsList.join(', '));
     return this.runSql(sql).nodeify(callback);
   },
 

--- a/test/driver/mysql_test.js
+++ b/test/driver/mysql_test.js
@@ -349,7 +349,9 @@ driver.connect(config, internals, function(err, db) {
           id: { type: dataType.INTEGER, primaryKey: true, autoIncrement: true },
           title: { type: dataType.STRING }
         }, function() {
-          db.addIndex('event', 'event_title', 'title', this.callback.bind(this, null));
+          db.addIndex('event', 'event_title', 'title', function() {
+            db.addIndex('event', 'event_title_sub_part', { name: 'title', length: 8 }, this.callback.bind(this, null));
+          }.bind(this));
         }.bind(this));
       },
 
@@ -384,13 +386,20 @@ driver.connect(config, internals, function(err, db) {
           }.bind(this));
         },
 
-        'with additional index': function(err, indexes) {
+        'with additional indexes': function(err, indexes) {
           assert.isNotNull(indexes);
-          assert.equal(indexes.length, 2);
+          assert.equal(indexes.length, 3);
+
           var index = findByName(indexes, 'event_title');
           assert.equal(index.getName(), 'event_title');
           assert.equal(index.getTableName(), 'event');
           assert.equal(index.getColumnName(), 'title');
+
+          var indexSubpart = findByName(indexes, 'event_title_sub_part');
+          assert.equal(indexSubpart.getName(), 'event_title_sub_part');
+          assert.equal(indexSubpart.getTableName(), 'event');
+          assert.equal(indexSubpart.getColumnName(), 'title');
+          assert.equal(indexSubpart.meta.sub_part, '8');
         }
       }
     }


### PR DESCRIPTION
MySQL has a capability to specify index length when creating indices. This pull request is about to add such capability to node-db-migrate.

To specify index length define columns as objects, e.g.:
```
db.addIndex('table', 'index', [
  { name: 'columnA', length: 12}, 
  { name: 'columnB', length: 4},
  'columnC'
])
```