### PR TITLE
Create migrations table in specified schema

### DIFF
--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -171,17 +171,22 @@ var PgDriver = Base.extend({
             }
 
             this.all('SET search_path TO ' + searchPath, function() {
-                this.all("SELECT table_name FROM information_schema.tables WHERE table_name = '" + global.migrationTable + "'", function(err, result) {
-                  if (err) {
-                    return callback(err);
-                  }
+                this.all("SELECT table_name FROM information_schema.tables WHERE table_name = '" +
+                  global.migrationTable + "'" +
+                  (this.schema ?
+                    " AND table_schema = '" + this.schema + "'" :
+                    ''),
+                  function(err, result) {
+                    if (err) {
+                      return callback(err);
+                    }
 
-                  if (result && result && result.length < 1) {
-                    this.createTable(global.migrationTable, options, callback);
-                  } else {
-                    callback();
-                  }
-                }.bind(this));
+                    if (result && result && result.length < 1) {
+                      this.createTable(global.migrationTable, options, callback);
+                    } else {
+                      callback();
+                    }
+                  }.bind(this));
             }.bind(this));
         }.bind(this));
       }.bind(this));

--- a/test/driver/pg_schema_test.js
+++ b/test/driver/pg_schema_test.js
@@ -1,4 +1,5 @@
 var vows = require('vows');
+var async = require('async');
 var assert = require('assert');
 var dbmeta = require('db-meta');
 var pg = require('pg');
@@ -46,6 +47,57 @@ vows.describe('pg').addBatch({
         teardown: function(db, client) {
             var callback = this.callback;
             client.query('DROP SCHEMA "test-schema" CASCADE', function (err) {
+              if (err) { return callback(err); }
+              client.end();
+              callback();
+          });
+        }
+    }
+})
+.addBatch({
+    'create schema and a public.migrations table and connect': {
+        topic: function() {
+            var callback = this.callback;
+            var client = new pg.Client(databaseUrl);
+
+            client.connect(function (err) {
+                if (err) { return callback(err); }
+                async.parallel([
+                  client.query.bind(client, 'CREATE SCHEMA test_schema'),
+                  client.query.bind(client, 'CREATE TABLE migrations ()')
+                ], function(err) {
+                    if (err) { return callback(err); }
+                    driver.connect({ driver: 'pg', database: 'db_migrate_test', schema: 'test_schema' }, function(err, db) {
+                        callback(err, db, client);
+                    });
+                });
+            });
+        },
+
+        'migrations table': {
+            topic: function(db, client) {
+                var callback = this.callback;
+
+                db.createMigrationsTable(function() {
+                    client.query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'test_schema' AND table_name = 'migrations'", function(err, result) {
+                        callback(err, result);
+                    });
+                });
+            },
+
+            'is in test_schema': function(err, result) {
+                assert.isNull(err);
+                assert.isNotNull(result);
+                assert.equal(result.rowCount, 1);
+            }
+        },
+
+        teardown: function(db, client) {
+            var callback = this.callback;
+            async.parallel([
+              client.query.bind(client, 'DROP SCHEMA test_schema CASCADE'),
+              client.query.bind(client, 'DROP TABLE migrations')
+            ], function (err) {
               if (err) { return callback(err); }
               client.end();
               callback();


### PR DESCRIPTION
In postgres, if you create a migrations table in one schema of your database,
and then try to use this for migrations in another schema, it will not create
the migrations table in the second schema which will prevent any migrations
from running on that schema. This creates the migrations table in that second
schema when the schema parameter is specified.