### PR TITLE
Support setting default environment via ENV variable.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -69,8 +69,12 @@ exports.load = function(fileName, currentEnv) {
     out.setCurrent(currentEnv);
   } else if(config['default']) {
     out.setCurrent(config['default']);
-  } else if(config.env) {
-    out.setCurrent(config.env);
+  } else if(config.defaultEnv) {
+    if (config.defaultEnv.ENV) {
+      out.setCurrent(process.env[config.defaultEnv.ENV]);
+    } else {
+      out.setCurrent(config.defaultEnv);
+    }
   } else {
     out.setCurrent(['dev', 'development']);
   }

--- a/test/config_test.js
+++ b/test/config_test.js
@@ -45,6 +45,34 @@ vows.describe('config').addBatch({
     }
   }
 }).addBatch({
+  'loading from a file with default env option': {
+    topic: function() {
+      var configPath = path.join(__dirname, 'database_with_default_env.json');
+      return config.load(configPath);
+    },
+
+    'should load a value from the default env': function (config) {
+      var current = config.getCurrent();
+      assert.equal(current.env, 'local');
+      assert.equal(current.settings.driver, 'sqlite3');
+      assert.equal(current.settings.filename, ':memory:');
+    },
+  }
+}).addBatch({
+  'loading from a file with default env option in ENV variable': {
+    topic: function() {
+      process.env['NODE_ENV'] = 'local';
+      var configPath = path.join(__dirname, 'database_with_default_env_from_env.json');
+      return config.load(configPath);
+    },
+
+    'should load a value from the env set in NODE_ENV': function (config) {
+      var current = config.getCurrent();
+      assert.equal(current.settings.driver, 'sqlite3');
+      assert.equal(current.settings.filename, ':memory:');
+    },
+  }
+}).addBatch({
   'loading from a file with ENV vars': {
     topic: function() {
       process.env['DB_MIGRATE_TEST_VAR'] = 'username_from_env';

--- a/test/database_with_default_env.json
+++ b/test/database_with_default_env.json
@@ -1,0 +1,7 @@
+{
+  "defaultEnv": "local",
+  "local": {
+    "driver": "sqlite3",
+    "filename": ":memory:"
+  }
+}

--- a/test/database_with_default_env_from_env.json
+++ b/test/database_with_default_env_from_env.json
@@ -1,0 +1,7 @@
+{
+  "defaultEnv": {"ENV": "NODE_ENV"},
+  "local": {
+    "driver": "sqlite3",
+    "filename": ":memory:"
+  }
+}


### PR DESCRIPTION
This change allows for a user to set the default environment via an environment variable.

Issue db-migrate/node-db-migrate#219 with commit https://github.com/db-migrate/node-db-migrate/commit/ce69a1f4573aaf8d55071d0aadc975cd1fa77eb0#diff-f7bf2b665273dfa66ffa4ad7c0a52bb9R44 added support for setting the default environment in `database.json`, which looks like:

```json
{
  "env": "local",
  "local": {
    "driver": "sqlite3",
    "filename": ":memory:"
   }
}
```

This PR takes that one step further and allows that default `env` to be an ENV variable, just like any other variable in `database.json`:

```json
{
  "env": {"ENV": "NODE_ENV"},
  "local": {
    "driver": "sqlite3",
    "filename": ":memory:"
   }
}
```

This would now allow those who use already rely on the `NODE_ENV` variable for other components of their project to select environments:

```bash
export NODE_ENV=local
db-migrate up
```
