### PR TITLE
Configuration through options object

### DIFF
--- a/api.js
+++ b/api.js
@@ -45,6 +45,11 @@ function dbmigrate(isModule, options, callback) {
 
     if (typeof(options.config) === 'string')
       internals.configFile = options.string;
+    else if (typeof(options.config) === 'object')
+      internals.configObject = options.config;
+
+    if (typeof(options.env) === 'string')
+      internals.currentEnv = options.env;
 
     if (typeof(options.cwd) === 'string')
       internals.cwd = options.cwd;
@@ -492,11 +497,15 @@ function createMigrationDir(dir, callback) {
 }
 
 function loadConfig( config, internals ) {
-  var out;
+  var out,
+      currentEnv = internals.currentEnv || internals.argv.env;
+
   if (process.env.DATABASE_URL) {
-    out = config.loadUrl(process.env.DATABASE_URL, internals.argv.env);
+    out = config.loadUrl(process.env.DATABASE_URL, currentEnv);
+  } else if (internals.configObject) {
+    out = config.loadObject(internals.configObject, currentEnv);
   } else {
-    out = config.load(internals.argv.config, internals.argv.env);
+    out = config.loadFile(internals.argv.config, currentEnv);
   }
   if (internals.verbose) {
     var current = out.getCurrent();

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,14 +28,22 @@ Config.prototype = {
   setCurrent: setCurrent
 };
 
-exports.load = function(fileName, currentEnv) {
+exports.load = function(config, currentEnv) {
+  if (typeof(config) === 'object') {
+    return exports.loadObject(config, currentEnv);
+  } else {
+    return exports.loadFile(config, currentEnv);
+  }
+};
+
+exports.loadFile = function(fileName, currentEnv) {
+  var config;
+
   try {
     fs.statSync(fileName);
   } catch(e) {
     throw new Error('Could not find database config file \'' + fileName + '\'');
   }
-  var config,
-      out = new Config();
 
   try {
     config = require(fileName);
@@ -47,6 +55,12 @@ exports.load = function(fileName, currentEnv) {
 
     config = require(path.join(process.cwd(), fileName));
   }
+
+  return exports.loadObject(config, currentEnv);
+};
+
+exports.loadObject = function(config, currentEnv) {
+  var out = new Config();
 
   for (var env in config) {
     if (config[env].ENV) {

--- a/test/integration/api_test.js
+++ b/test/integration/api_test.js
@@ -77,4 +77,31 @@ vows.describe('api').addBatch({
       assert.isTrue(called);
     }
   }
+}).addBatch({
+  'load config from parameter': {
+    topic: function() {
+      var options = {
+        env: 'dev',
+        cwd: process.cwd() + '/test/integration',
+        config: {
+          dev: {
+            driver: 'sqlite3',
+            filename: ':memory:'
+          },
+          pg: {
+            driver: 'pg',
+            database: 'db_api_test'
+          }
+        }
+      };
+      var api = DBMigrate.getInstance(true, options);
+      return {options: options, api: api};
+    },
+    'should load config from parameter': function(topic) {
+      var actual = topic.api.config;
+      var expected = topic.options.config;
+      expected.getCurrent = actual.getCurrent;
+      assert.deepEqual(actual, expected);
+    }
+  }
 }).export(module);


### PR DESCRIPTION
Extend the programmatic API to
* supply `options.config` as an object
* supply `options.env` as the currentEnv option

Example:

```javascript
var dbm = DBMigrate.getInstance(true, {
  env: config.get('DB_ENV'),
  config: {
    development: {
      driver: 'sqlite3',
      filename: ':memory:'
    },
    sqlite: {
      driver: 'sqlite3',
      filename: config.get('SQLITE_FILE')
    }
});
```

Documentation: https://github.com/db-migrate/english-docs/pull/3