### PR TITLE
Fix typo setting the config file in api.js

### DIFF
--- a/api.js
+++ b/api.js
@@ -44,7 +44,7 @@ function dbmigrate(isModule, options, callback) {
   if (typeof(options) === 'object') {
 
     if (typeof(options.config) === 'string')
-      internals.configFile = options.string;
+      internals.configFile = options.config;
     else if (typeof(options.config) === 'object')
       internals.configObject = options.config;
 


### PR DESCRIPTION
Fixed a typo which set the config file to `options.string` instead of `options.config`.