### PR TITLE
Fix 'TypeError: undefined is not a function' in 0.9.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "async": "~0.9.0",
+    "bluebird": "^3.2.2",
     "dotenv": "~0.5.1",
     "final-fs": "^1.6.0",
     "mkdirp": "~0.5.0",


### PR DESCRIPTION
TL;DR - Add the promise library as a dependency.

The promise library (bluebird) used in v10.x-beta is missing from the current release: 0.9.23. As a result, when you install db-migrate on a clean system and run it, you get an 'undefined' error when the generated code attempts to instantiate a Promise.

This is with Node v0.12.10.

```
db-migrate -v up:api
[INFO] Using dev settings: { host: '[redacted]',
  user: 'db-migrate',
  password: '******',
  driver: 'mysql',
  multipleStatements: true }
[INFO] require: ./mysql
[INFO] connecting
[INFO] connected
[INFO] loaded extra config for migration subfolder: "api/config.json"
[SQL] USE `api`
[INFO] creating table: migrations
[SQL] CREATE TABLE IF NOT EXISTS `migrations` (`id` INTEGER  PRIMARY KEY AUTO_INCREMENT NOT NULL, `name` VARCHAR (255) NOT NULL, `run_on` DATETIME  NOT NULL)
[INFO] migration table created
[INFO] loading migrations from dir /home/ubuntu/migrations/api
[INFO] loading migrations from database
[SQL] SELECT * FROM `migrations` ORDER BY run_on DESC, name DESC
[INFO] preparing to run up migration: 20160210180117-initial-api-database
[ERROR] TypeError: undefined is not a function
    at exports.up (/home/ubuntu/migrations/api/20160210180117-initial-api-database.js:23:10)
    at Migration._up (/usr/lib/node_modules/db-migrate/lib/migration.js:172:32)
    at Migration.up (/usr/lib/node_modules/db-migrate/lib/migration.js:184:8)
    at Object.Migrator.up (/usr/lib/node_modules/db-migrate/lib/migrator.js:84:7)
    at /usr/lib/node_modules/db-migrate/lib/migrator.js:116:18
    at Class.module.exports.Class.extend.startMigration (/usr/lib/node_modules/db-migrate/lib/driver/base.js:278:32)
    at /usr/lib/node_modules/db-migrate/lib/migrator.js:115:23
    at iterate (/usr/lib/node_modules/db-migrate/node_modules/async/lib/async.js:146:13)
    at Object.async.eachSeries (/usr/lib/node_modules/db-migrate/node_modules/async/lib/async.js:162:9)
    at /usr/lib/node_modules/db-migrate/lib/migrator.js:113:15
```

The line of code from [timestamp]-initial-api-database.js referenced in the stack trace:

```javascript
  return new Promise( function( resolve, reject ) {
```

If you then install bluebird with `npm install bluebird -g` and re-run db-migrate, it works as expected.