### PR TITLE
Avoid warning in promise/callback bridge code

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -168,14 +168,7 @@ Migrator.prototype = {
           })
           .then(self.driver.endMigration.bind(self.driver));
         })
-        .then(function() {
-          callback();
-        })
-        .catch(function(e) {
-
-          throw e;
-        });
-
+        .nodeify(callback);
       });
     });
   },
@@ -221,13 +214,7 @@ Migrator.prototype = {
         })
         .then(self.driver.endMigration.bind(self.driver));
       })
-      .then(function() {
-        callback();
-      })
-      .catch(function(e) {
-
-        throw e;
-      });
+      .nodeify(callback);
     });
   }
 };


### PR DESCRIPTION
When Bluebird detects when a promise is created within a promise
handler, but is not returned, it [emits a warning][warn] 'a promise was
created in a handler but was not returned from it'.

This happens if the `callback()` function is implemented using Promises,
but uses `nodeify()` to make it callback compatible. By using nodeify
here, it handles the returned Promise (if any) and avoids the warning.

 [warn]: https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md