### PR TITLE
Support for Cassandra Map, List and Set datatypes

### DIFF
--- a/lib/data_type.js
+++ b/lib/data_type.js
@@ -13,5 +13,8 @@ module.exports = {
   TIMESTAMP: 'timestamp',
   BINARY: 'binary',
   BOOLEAN: 'boolean',
-  DECIMAL: 'decimal'
+  DECIMAL: 'decimal',
+  MAP: 'map',
+  LIST: 'list',
+  SET: 'set'
 };


### PR DESCRIPTION
If there's no other complex requirements to make this work with upstream, can we add support for Cassandra Map, List and Set datatypes?

I understand that this might affect [base.js](https://github.com/db-migrate/db-migrate-base/blob/master/index.js#L31) as well.