### PR TITLE
Add docker-compose.yml to start databases in Docker containers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ If so, here's a quick guide to creating a great pull request for
 this project:
 
 1. Fork the repo.
+  * **NOTE**: Optionally start the databases using `docker-compose up`
 
 2. Copy the test/db.config.example.json to test/db.config.json
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+  pg:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: db-migrate
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: db_migrate_test
+    ports:
+      - 5432:5432
+  mongo:
+    image: mongo:latest
+    ports:
+      - 27017:27017
+  mysql:
+    image: mysql:latest
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_USER: db-migrate
+      MYSQL_PASSWORD: pass
+      MYSQL_DATABASE: db_migrate_test
+    ports:
+      - 3306:3306


### PR DESCRIPTION
I've added a `docker-compose.yml` configuration file to start the following databases: `mysql`, `postgres` and `mongo`.

Test are still failing because some of the connection are hardcoded. I tried to have a look but I could not understand the logic so I didn't touch anything.
