### PR TITLE
Opt-in ES6 support via babel-register

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -4,6 +4,9 @@ var log = require('db-migrate-shared').log;
 var Skeleton = require('./skeleton');
 
 var filesRegEx = /\.js$/;
+try {
+  require('babel-register');
+} catch (e) {}
 var coffeeSupported = false;
 var coffeeModule = null;
 try {

--- a/lib/seed.js
+++ b/lib/seed.js
@@ -4,6 +4,9 @@ var log = require('db-migrate-shared').log;
 var Skeleton = require('./skeleton');
 
 var filesRegEx = /\.js$/;
+try {
+  require('babel-register');
+} catch (e) {}
 var coffeeSupported = false;
 var coffeeModule = null;
 try {


### PR DESCRIPTION
Fixes #289
Possibly removes the need for #340?

I was trying to find the easiest way to support the new import/export syntax via Babel from within the migrations so that they would pass my ESLint rules and be consistent with the rest of my app. I remembered that you've had coffee-script support for ages, so I figured it might be possible to add Babel support the same way; and it worked!

To use it, the user would opt-in by doing `npm install babel-register` - that's all.

I don't think this breaks backwards compatibility since babel runs vanilla ES3/ES5 javascript code just fine; so whether or not the project has `babel-register` installed already I don't see any negative consequences (except an almost negligible performance cost?)

I couldn't add tests for this because that would require modifying the package.json to require `babel-register` and thus all tests would then use babel's parser.

If you think this is a good idea I'd be happy to update the relevant docs with a couple sentences about it - just point me to the relevant places.
