### PR TITLE
log full error on uncaught exception or unhandled rejection

### DIFF
--- a/api.js
+++ b/api.js
@@ -76,12 +76,12 @@ function dbmigrate(isModule, options, callback) {
 function registerEvents() {
 
   process.on('uncaughtException', function(err) {
-    log.error(err.stack);
+    log.error(err);
     process.exit(1);
   });
 
   process.on('unhandledRejection', function(reason) {
-    log.error(reason.stack);
+    log.error(reason);
     process.exit(1);
   });
 }


### PR DESCRIPTION
Currently the top level exception handlers log the stack of the error. However in many cases this is undefined.

This PR logs the complete error object as is the case in other parts of the codebase.

My specific use case is that I'm running migrations programmatically and I'm unable to debug the issue because the contents of the error are lost.
