### PR TITLE
[V0.9.x] Transactionless migrations for PostgreSql

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Options:
   --config                    Location of the database.json file.             [default: "./database.json"]
   --force-exit                Call system.exit() after migration run          [default: false]
   --sql-file                  Create sql files for up and down.               [default: false]
+  --transactionless           Creates a non-trasactional migration.           [default: false]
   --coffee-file               Create a coffeescript migration file            [default: false]
   --migration-table           Set the name of the migration table.
   --table, --migration-table                                                  [default: "migrations"]

--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -13,24 +13,26 @@ var pkginfo = require('pkginfo')(module, 'version');
 var dotenv = require('dotenv');
 
 //global declaration for detection like it's done in umigrate
-dbm = require( '../' );
-async = require( 'async' );
+dbm = require('../');
+async = require('async');
 
-dotenv.load({ silent: true });
+dotenv.load({silent: true});
 
-process.on('uncaughtException', function(err) {
-  log.error(err.stack);
-  process.exit(1);
+process.on('uncaughtException', function (err) {
+    log.error(err.stack);
+    process.exit(1);
 });
 
 var argv = optimist
     .default({
-      verbose: false,
-      table: 'migrations',
-      'force-exit': false,
-      'sql-file': false,
-      config: process.cwd() + '/database.json',
-      'migrations-dir': process.cwd() + '/migrations' })
+        verbose: false,
+        table: 'migrations',
+        'force-exit': false,
+        'sql-file': false,
+        'transactionless': false,
+        config: process.cwd() + '/database.json',
+        'migrations-dir': process.cwd() + '/migrations'
+    })
     .usage('Usage: db-migrate [up|down|reset|create|db] [[dbname/]migrationName|all] [options]')
 
     .describe('env', 'The environment to run the migrations under (dev, test, prod).')
@@ -69,6 +71,9 @@ var argv = optimist
     .describe('sql-file', 'Automatically create two sql files for up and down statements in /sqls and generate the javascript code that loads them.')
     .boolean('sql-file')
 
+    .describe('transactionless', 'Creates a non-trasactional migration. Only for PostgreSQL non-transactional DDL changes, eg: ALTER TYPE [...] ADD VALUE')
+    .boolean('transactionless')
+
     .describe('coffee-file', 'Create a coffeescript migration file')
     .boolean('coffee-file')
 
@@ -80,13 +85,13 @@ var argv = optimist
     .argv;
 
 if (argv.version) {
-  console.log(module.exports.version);
-  process.exit(0);
+    console.log(module.exports.version);
+    process.exit(0);
 }
 
 if (argv.help || argv._.length === 0) {
-  optimist.showHelp();
-  process.exit(1);
+    optimist.showHelp();
+    process.exit(1);
 }
 
 global.migrationTable = argv.table;
@@ -96,278 +101,276 @@ global.matching = '';
 global.mode;
 global.verbose = argv.verbose;
 global.dryRun = argv['dry-run'];
-if(global.dryRun) {
-  log.info('dry run');
+if (global.dryRun) {
+    log.info('dry run');
 }
 
 function createMigrationDir(dir, callback) {
-  fs.stat(dir, function(err, stat) {
-    if (err) {
-      mkdirp(dir, callback);
-    } else {
-      callback();
-    }
-  });
+    fs.stat(dir, function (err, stat) {
+        if (err) {
+            mkdirp(dir, callback);
+        } else {
+            callback();
+        }
+    });
 }
 
 function loadConfig() {
-  if (process.env.DATABASE_URL) {
-    config.loadUrl(process.env.DATABASE_URL, argv.env);
-  } else {
-    config.load(argv.config, argv.env);
-  }
-  if(verbose) {
-    var current = config.getCurrent();
-    var s = JSON.parse(JSON.stringify(current.settings));
+    if (process.env.DATABASE_URL) {
+        config.loadUrl(process.env.DATABASE_URL, argv.env);
+    } else {
+        config.load(argv.config, argv.env);
+    }
+    if (verbose) {
+        var current = config.getCurrent();
+        var s = JSON.parse(JSON.stringify(current.settings));
 
-    if (s["password"])
-      s["password"] = "******";
+        if (s["password"])
+            s["password"] = "******";
 
-    log.info('Using', current.env, 'settings:', s);
-  }
+        log.info('Using', current.env, 'settings:', s);
+    }
 }
 
 function executeCreate() {
-  var folder, path;
+    var folder, path;
 
-  if(argv._.length === 0) {
-    log.error('\'migrationName\' is required.');
-    optimist.showHelp();
-    process.exit(1);
-  }
-
-  createMigrationDir(argv['migrations-dir'], function(err) {
-    if (err) {
-      log.error('Failed to create migration directory at ', argv['migrations-dir'], err);
-      process.exit(1);
+    if (argv._.length === 0) {
+        log.error('\'migrationName\' is required.');
+        optimist.showHelp();
+        process.exit(1);
     }
 
-    argv.title = argv._.shift();
-    folder = argv.title.split('/');
+    createMigrationDir(argv['migrations-dir'], function (err) {
+        if (err) {
+            log.error('Failed to create migration directory at ', argv['migrations-dir'], err);
+            process.exit(1);
+        }
 
-    argv.title = folder[folder.length - 2] || folder[0];
-    path = argv['migrations-dir'];
+        argv.title = argv._.shift();
+        folder = argv.title.split('/');
 
-    if(folder.length > 1) {
+        argv.title = folder[folder.length - 2] || folder[0];
+        path = argv['migrations-dir'];
 
-      path += '/';
+        if (folder.length > 1) {
 
-      for(var i = 0; i < folder.length - 1; ++i) {
+            path += '/';
 
-        path += folder[i] + '/';
-      }
-    }
+            for (var i = 0; i < folder.length - 1; ++i) {
 
-    var templateType = Migration.TemplateType.DEFAULT_JS;
-    if (shouldCreateSqlFiles()) {
-      templateType = Migration.TemplateType.SQL_FILE_LOADER;
-    } else if (shouldCreateCoffeeFile()) {
-      templateType = Migration.TemplateType.DEFAULT_COFFEE;
-    }
-    var migration = new Migration(argv.title + (shouldCreateCoffeeFile() ? '.coffee' : '.js'), path, new Date(), templateType);
-    index.createMigration(migration, function(err, migration) {
-      assert.ifError(err);
-      log.info(util.format('Created migration at %s', migration.path));
+                path += folder[i] + '/';
+            }
+        }
+
+        var templateType = Migration.TemplateType.DEFAULT_JS;
+        if (shouldCreateSqlFiles()) {
+            templateType = Migration.TemplateType.SQL_FILE_LOADER;
+        } else if (shouldCreateCoffeeFile()) {
+            templateType = Migration.TemplateType.DEFAULT_COFFEE;
+        }
+        var migration = new Migration(argv.title + (shouldCreateCoffeeFile() ? '.coffee' : '.js'), path, new Date(), templateType, shouldCreateTransactionless());
+        index.createMigration(migration, function (err, migration) {
+            assert.ifError(err);
+            log.info(util.format('Created migration at %s', migration.path));
+        });
     });
-  });
 
-  if (shouldCreateSqlFiles()) {
-    createSqlFiles();
-  }
+    if (shouldCreateSqlFiles()) {
+        createSqlFiles();
+    }
 }
 
 function shouldCreateSqlFiles() {
-  return argv['sql-file'] || config['sql-file'];
+    return argv['sql-file'] || config['sql-file'];
+}
+
+function shouldCreateTransactionless() {
+    return argv['transactionless'];
 }
 
 function shouldCreateCoffeeFile() {
-  return argv['coffee-file'] || config['coffee-file'];
+    return argv['coffee-file'] || config['coffee-file'];
 }
 
 function createSqlFiles() {
-  var sqlDir = argv['migrations-dir'] + '/sqls';
-  createMigrationDir(sqlDir, function(err) {
-    if (err) {
-      log.error('Failed to create migration directory at ', sqlDir, err);
-      process.exit(1);
-    }
+    var sqlDir = argv['migrations-dir'] + '/sqls';
+    createMigrationDir(sqlDir, function (err) {
+        if (err) {
+            log.error('Failed to create migration directory at ', sqlDir, err);
+            process.exit(1);
+        }
 
-    var templateTypeDefaultSQL = Migration.TemplateType.DEFAULT_SQL;
-    var migrationUpSQL = new Migration(argv.title + '-up.sql', sqlDir, new Date(), templateTypeDefaultSQL);
-    index.createMigration(migrationUpSQL, function(err, migration) {
-      assert.ifError(err);
-      log.info(util.format('Created migration up sql file at %s', migration.path));
+        var templateTypeDefaultSQL = Migration.TemplateType.DEFAULT_SQL;
+        var migrationUpSQL = new Migration(argv.title + '-up.sql', sqlDir, new Date(), templateTypeDefaultSQL, shouldCreateTransactionless());
+        index.createMigration(migrationUpSQL, function (err, migration) {
+            assert.ifError(err);
+            log.info(util.format('Created migration up sql file at %s', migration.path));
+        });
+        var migrationDownSQL = new Migration(argv.title + '-down.sql', sqlDir, new Date(), templateTypeDefaultSQL, shouldCreateTransactionless());
+        index.createMigration(migrationDownSQL, function (err, migration) {
+            assert.ifError(err);
+            log.info(util.format('Created migration down sql file at %s', migration.path));
+        });
     });
-    var migrationDownSQL = new Migration(argv.title + '-down.sql', sqlDir, new Date(), templateTypeDefaultSQL);
-    index.createMigration(migrationDownSQL, function(err, migration) {
-      assert.ifError(err);
-      log.info(util.format('Created migration down sql file at %s', migration.path));
-    });
-  });
 }
 
 function executeUp() {
 
-  if(!argv.count) {
-    argv.count = Number.MAX_VALUE;
-  }
+    if (!argv.count) {
+        argv.count = Number.MAX_VALUE;
+    }
 
-  index.connect(config.getCurrent().settings, function(err, migrator) {
-    assert.ifError(err);
+    index.connect(config.getCurrent().settings, function (err, migrator) {
+        assert.ifError(err);
 
-    if(global.locTitle)
-        migrator.migrationsDir = path.resolve(argv['migrations-dir'], global.locTitle);
-    else
-      migrator.migrationsDir = path.resolve(argv['migrations-dir']);
+        if (global.locTitle)
+            migrator.migrationsDir = path.resolve(argv['migrations-dir'], global.locTitle);
+        else
+            migrator.migrationsDir = path.resolve(argv['migrations-dir']);
 
-    migrator.driver.createMigrationsTable(function(err) {
-      assert.ifError(err);
-      log.verbose('migration table created');
-      migrator.up(argv, onComplete.bind(this, migrator));
+        migrator.driver.createMigrationsTable(function (err) {
+            assert.ifError(err);
+            log.verbose('migration table created');
+            migrator.up(argv, onComplete.bind(this, migrator));
+        });
     });
-  });
 }
 
 function executeDown() {
 
-  if(!argv.count) {
-    log.info('Defaulting to running 1 down migration.');
-    argv.count = 1;
-  }
+    if (!argv.count) {
+        log.info('Defaulting to running 1 down migration.');
+        argv.count = 1;
+    }
 
-  index.connect(config.getCurrent().settings, function(err, migrator) {
-    assert.ifError(err);
+    index.connect(config.getCurrent().settings, function (err, migrator) {
+        assert.ifError(err);
 
-    migrator.migrationsDir = path.resolve(argv['migrations-dir']);
+        migrator.migrationsDir = path.resolve(argv['migrations-dir']);
 
-    migrator.driver.createMigrationsTable(function(err) {
-      assert.ifError(err);
-      migrator.down(argv, onComplete.bind(this, migrator));
+        migrator.driver.createMigrationsTable(function (err) {
+            assert.ifError(err);
+            migrator.down(argv, onComplete.bind(this, migrator));
+        });
     });
-  });
 }
 
 function executeDB() {
 
-  if(argv._.length > 0) {
-    argv.dbname = argv._.shift().toString();
-  }
-  else {
-
-    log.info('Error: You must enter a database name!');
-    return;
-  }
-
-  index.driver(config.getCurrent().settings, function(err, db)
-  {
-    if(global.mode === 'create')
-    {
-      db.createDatabase(argv.dbname, { ifNotExists: true }, function()
-      {
-        if(err) {
-          log.info('Error: Failed to create database!');
-        }
-        else {
-          log.info('Created database "' + argv.dbname + '"');
-        }
-
-        db.close();
-      });
+    if (argv._.length > 0) {
+        argv.dbname = argv._.shift().toString();
     }
-    else if(global.mode === 'drop')
-    {
-      db.dropDatabase(argv.dbname, { ifExists: true }, function()
-      {
-        if(err) {
-          log.info('Error: Failed to drop database!');
-        }
-        else {
-          log.info('Deleted database "' + argv.dbname + '"');
-        }
+    else {
 
-        db.close();
-      });
+        log.info('Error: You must enter a database name!');
+        return;
     }
-    else
-      return;
-  });
+
+    index.driver(config.getCurrent().settings, function (err, db) {
+        if (global.mode === 'create') {
+            db.createDatabase(argv.dbname, {ifNotExists: true}, function () {
+                if (err) {
+                    log.info('Error: Failed to create database!');
+                }
+                else {
+                    log.info('Created database "' + argv.dbname + '"');
+                }
+
+                db.close();
+            });
+        }
+        else if (global.mode === 'drop') {
+            db.dropDatabase(argv.dbname, {ifExists: true}, function () {
+                if (err) {
+                    log.info('Error: Failed to drop database!');
+                }
+                else {
+                    log.info('Deleted database "' + argv.dbname + '"');
+                }
+
+                db.close();
+            });
+        }
+        else
+            return;
+    });
 
 }
 
 function onComplete(migrator, originalErr) {
-  migrator.driver.close(function(err) {
-    assert.ifError(originalErr);
-    assert.ifError(err);
-    log.info('Done');
-  });
+    migrator.driver.close(function (err) {
+        assert.ifError(originalErr);
+        assert.ifError(err);
+        log.info('Done');
+    });
 }
 
 function run() {
-  var action = argv._.shift(),
-      folder = action.split(':');
+    var action = argv._.shift(),
+        folder = action.split(':');
 
-  action = folder[0];
+    action = folder[0];
 
-  switch(action) {
-    case 'create':
-      loadConfig();
-      executeCreate();
-      break;
-    case 'up':
-    case 'down':
-    case 'reset':
-      loadConfig();
+    switch (action) {
+        case 'create':
+            loadConfig();
+            executeCreate();
+            break;
+        case 'up':
+        case 'down':
+        case 'reset':
+            loadConfig();
 
-      if(action === 'reset')
-        argv.count = Number.MAX_VALUE;
+            if (action === 'reset')
+                argv.count = Number.MAX_VALUE;
 
-      if(argv._.length > 0) {
-        if (action === 'down') {
-          log.info('Ignoring migration name for down migrations.  Use --count to control how many down migrations are run.');
-          argv.destination = null;
-        } else {
-          argv.destination = argv._.shift().toString();
-        }
-      }
+            if (argv._.length > 0) {
+                if (action === 'down') {
+                    log.info('Ignoring migration name for down migrations.  Use --count to control how many down migrations are run.');
+                    argv.destination = null;
+                } else {
+                    argv.destination = argv._.shift().toString();
+                }
+            }
 
-      if(folder[1])
-      {
-        global.matching = folder[1];
-        global.migrationMode = folder[1];
-      }
+            if (folder[1]) {
+                global.matching = folder[1];
+                global.migrationMode = folder[1];
+            }
 
-      if(action == 'up') {
-        executeUp();
-      } else {
-        executeDown();
-      }
-      break;
+            if (action == 'up') {
+                executeUp();
+            } else {
+                executeDown();
+            }
+            break;
 
-    case 'db':
-      loadConfig();
+        case 'db':
+            loadConfig();
 
-      if(folder.length < 1) {
+            if (folder.length < 1) {
 
-        log.info('Please enter a valid command, i.e. db:create|db:drop');
-      }
-      else {
+                log.info('Please enter a valid command, i.e. db:create|db:drop');
+            }
+            else {
 
-        global.mode = folder[1];
-        executeDB();
-      }
-    break;
+                global.mode = folder[1];
+                executeDB();
+            }
+            break;
 
-    default:
-      log.error('Invalid Action: Must be [up|down|create].');
-      optimist.showHelp();
-      process.exit(1);
-      break;
-  }
+        default:
+            log.error('Invalid Action: Must be [up|down|create].');
+            optimist.showHelp();
+            process.exit(1);
+            break;
+    }
 }
 
 run();
 
 if (argv['force-exit']) {
-  log.verbose('Forcing exit');
-  process.exit(0);
+    log.verbose('Forcing exit');
+    process.exit(0);
 }

--- a/lib/driver/pg.js
+++ b/lib/driver/pg.js
@@ -13,12 +13,24 @@ var PgDriver = Base.extend({
         this.connection.connect();
     },
 
-    startMigration: function(cb){
-        this.runSql('BEGIN;', function() { cb();});
+    startMigration: function(cb, runInTransaction){
+        if (runInTransaction !== true) {
+            cb();
+        } else {
+            this.runSql('BEGIN;', function () {
+                cb();
+            });
+        }
     },
 
-    endMigration: function(cb){
-        this.runSql('COMMIT;', function(){cb(null);});
+    endMigration: function(cb, runInTransaction){
+        if (runInTransaction !== true) {
+            cb(null);
+        } else {
+            this.runSql('COMMIT;', function () {
+                cb(null);
+            });
+        }
     },
 
     createColumnDef: function(name, spec, options) {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -19,8 +19,8 @@ function formatPath(dir, name) {
   return path.join(dir, name);
 }
 
-function formatName(title, date) {
-  return formatDate(date) + '-' + formatTitle(title);
+function formatName(title, date, transactionless) {
+  return formatDate(date) + '-' + (transactionless ? 'NO-TRANS-' : '') + formatTitle(title);
 }
 
 function formatDate(date) {
@@ -52,8 +52,12 @@ function parseDate(name) {
 
 function parseTitle(name) {
   var match = name.match(/\d{14}-([^\.]+)/);
-  var dashed = match[1];
+  var dashed = match[1].replace(/NO-TRANS(-)?/i,'');
   return inflection.humanize(dashed, true);
+}
+
+function parseTransactionless(name) {
+  return name.match(/NO-TRANS/i) === null;
 }
 
 function writeMigrationRecord(db, migration, callback) {
@@ -64,7 +68,8 @@ Migration = function() {
   if (arguments.length >= 3) {
     this.title = arguments[0];
     this.date = arguments[2];
-    this.name = formatName(this.title, this.date);
+    this.transactionless = arguments.length > 4 ? arguments[4] : false;
+    this.name = formatName(this.title, this.date, this.transactionless);
     this.path = formatPath(arguments[1], this.name);
     this.templateType = arguments[3];
   } else if (arguments.length == 1) {
@@ -72,6 +77,7 @@ Migration = function() {
     this.name = Migration.parseName(this.path);
     this.date = parseDate(this.name);
     this.title = parseTitle(this.name);
+    this.transactionless = parseTransactionless(this.name);
   }
 };
 

--- a/test/migration_test.js
+++ b/test/migration_test.js
@@ -8,6 +8,7 @@ var dirName = '/directory/name/';
 var fileNameNoExtension = 'filename';
 var fileName = 'filename.js';
 var templateType = Migration.TemplateType.SQL_FILE_LOADER;
+var transactionless = true;
 
 vows.describe('migration').addBatch({
   'when creating a new migration object': {
@@ -32,6 +33,35 @@ vows.describe('migration').addBatch({
       },
       'should have templateType not set': function(migration) {
         assert.equal(migration.templateType, undefined);
+      },
+      'should be executed in transaction': function(migration) {
+        assert.equal(migration.transactionless, true);
+      }
+    },
+    'with 1 parameter as the complete filepath and transactionless': {
+      topic: function() {
+        var migration = new Migration(dirName + dateString+'-NO-TRANS-'+fileName);
+        return migration;
+      },
+      'should have title set without file extension': function(migration) {
+        assert.equal(migration.title, fileNameNoExtension);
+      },
+      'should have date set': function(migration) {
+        migration.date.setMilliseconds(0);
+        date.setMilliseconds(0);
+        assert.equal(migration.date.getTime(), date.getTime());
+      },
+      'should have name set without file extension': function(migration) {
+        assert.equal(migration.name, dateString+'-NO-TRANS-'+fileNameNoExtension);
+      },
+      'should have path set': function(migration) {
+        assert.equal(migration.path, dirName+dateString+'-NO-TRANS-'+fileName);
+      },
+      'should have templateType not set': function(migration) {
+        assert.equal(migration.templateType, undefined);
+      },
+      'should be transactionless': function(migration) {
+        assert.equal(migration.transactionless, false);
       }
     },
     'with 3 parameters': {
@@ -74,6 +104,33 @@ vows.describe('migration').addBatch({
       },
       'should have templateType set': function(migration) {
         assert.equal(migration.templateType, templateType);
+      },
+      'should be transactionless': function(migration) {
+        assert.equal(migration.transactionless, false);
+      }
+    },
+    'with 5 parameters': {
+      topic: function() {
+        var migration = new Migration(fileName, dirName, date, templateType, transactionless);
+        return migration;
+      },
+      'should have title set': function(migration) {
+        assert.equal(migration.title, fileName);
+      },
+      'should have date set': function(migration) {
+        assert.equal(migration.date, date);
+      },
+      'should have name set': function(migration) {
+        assert.equal(migration.name, dateString+'-NO-TRANS-'+fileName);
+      },
+      'should have path set': function(migration) {
+        assert.equal(migration.path, dirName+dateString+'-NO-TRANS-'+fileName);
+      },
+      'should have templateType set': function(migration) {
+        assert.equal(migration.templateType, templateType);
+      },
+      'should be transactionless': function(migration) {
+        assert.equal(migration.transactionless, true);
       }
     }
   }


### PR DESCRIPTION
There are some actions in PostgreSQL that cannot be run in transactions.
For instance a: 
`ALTER TYPE image_type ADD VALUE IF NOT EXISTS 'gif'`
That will cause the following error when running db-migrate up:
[ERROR] error: ALTER TYPE ... ADD cannot run inside a transaction block

There are other migration libraries that support non-transnational migrations. Now there is a Posgresql migration for node that supports this: node-pg-migrate

As there is no way to set attributes for migrations, I have added to the filename a prefix 'NO-TRANS' to be able to determine if needs to be run within or without transaction.
I have also added some functionality and tests to enable this by adding the argument --transactionless to the db-migrate create.

Currently I am using 0.9 as is the version in npm. If you need me to do the same in master / 0.10 please let me know.

Thank you,
Francisco