### PR TITLE
Log error on undefined stack

### DIFF
--- a/api.js
+++ b/api.js
@@ -136,7 +136,7 @@ function dbmigrate(plugins, isModule, options, callback) {
 function registerEvents() {
 
   process.on('uncaughtException', function(err) {
-    log.error(err.stack);
+    log.error(err.stack || err);
     process.exit(1);
   });
 


### PR DESCRIPTION
With this;
~~~
exports.up = function () {
    throw 'my error'
}
~~~

Before PR;
~~~
[ERROR] undefined
~~~

After PR;
~~~
[ERROR] my error
~~~