### PR TITLE
Allow rc file to contain location of config file

### DIFF
--- a/lib/commands/set-default-argv.js
+++ b/lib/commands/set-default-argv.js
@@ -128,7 +128,7 @@ module.exports = function(internals, isModule) {
 
   internals.argv = deepExtend(internals.argv.argv, rc('db-migrate', {}));
   internals.argv.rcconfig = internals.argv.config;
-  internals.argv.config = _config;
+  internals.argv.config = internals.argv.configFile || _config;
 
   if (internals.argv.version) {
     console.log(internals.dbm.version);


### PR DESCRIPTION
## Problem
When putting a `database.json` file in a different directory, you need to call with the config file option each time. 

This is some extra overhead we don't want to deal with.

closes https://github.com/db-migrate/node-db-migrate/issues/451

## Solution
Allow the `rc` file to specify a `configFile` option. `config` is a protected word in the `rc` module which means we can't use that one.

The current solution is to simply disallow this.

Add some documentation updates
https://github.com/db-migrate/english-docs/pull/25

## Help required
Not sure how to test the configuration is loading correctly. Does anyone know of a good test to replicate for my own purposes.
Based on https://github.com/db-migrate/node-db-migrate/commit/b5e7c80a833c4e8eb0ef24838d810d393015a2c9, this seems untested.

## Disclaimer
I hereby release all copyrights to this work in perpetuity. (not sure if more is needed).

@wzrdtales Please