### PR TITLE
Remove `moment`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,7 +1528,8 @@
     "moment": {
       "version": "2.19.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
-      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA=="
+      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA==",
+      "dev": true
     },
     "mongodb-uri": {
       "version": "0.9.7",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "final-fs": "^1.6.0",
     "inflection": "^1.10.0",
     "mkdirp": "~0.5.0",
-    "moment": "^2.14.1",
     "optimist": "~0.6.1",
     "parse-database-url": "~0.3.0",
     "pkginfo": "^0.4.0",


### PR DESCRIPTION
It doesn't seem to be used or be a `peerDependency` and the current version has a security vulnerability.