### PR TITLE
Feature/run cleanly on node6 10

### DIFF
--- a/lib/commands/fn/plugin.js
+++ b/lib/commands/fn/plugin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const log = require('db-migrate-shared').log;
+var log = require('db-migrate-shared').log;
 
 function registerPluginLoader (plugins) {
   return {

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,37 @@ var parseDatabaseUrl = require('parse-database-url');
 var dbmUtil = require('db-migrate-shared').util;
 var log = require('db-migrate-shared').log;
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+if (typeof Object.assign !== 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, 'assign', {
+    value: function assign (target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target == null) { // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource != null) { // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
+}
+
 var setCurrent = (exports.setCurrent = function (env) {
   env = dbmUtil.isArray(env) ? env : [env];
   env.forEach(


### PR DESCRIPTION
# My Setup

* Node 6.10 on AWS Lambda

## What I expected

* Flawless execution ;)

## What I got

```
2018-02-03T22:34:44.577Z	6d024444-0932-11e8-b6ce-6557c1ca4e8c	Error: Command failed: node --harmony node_modules/db-migrate/bin/db-migrate up --env staging
[ERROR] TypeError: Object function Object() { [native code] } has no method 'assign'
at Object.exports.loadObject (/var/task/node_modules/db-migrate/lib/config.js:138:30)
at Object.exports.loadFile (/var/task/node_modules/db-migrate/lib/config.js:94:18)
at loadConfig (/var/task/node_modules/db-migrate/lib/commands/helper/load-config.js:12:18)
at Object.dbmigrate (/var/task/node_modules/db-migrate/api.js:66:43)
at Object.module.exports.getInstance (/var/task/node_modules/db-migrate/index.js:62:10)
at /var/task/node_modules/db-migrate/bin/db-migrate:32:25
at /var/task/node_modules/resolve/lib/async.js:45:21
at ondir (/var/task/node_modules/resolve/lib/async.js:196:27)
at onex (/var/task/node_modules/resolve/lib/async.js:104:32)
at /var/task/node_modules/resolve/lib/async.js:24:24

at ChildProcess.exithandler (child_process.js:204:12)
at emitTwo (events.js:106:13)
at ChildProcess.emit (events.js:191:7)
at maybeClose (internal/child_process.js:886:16)
at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
```

Before this, I also got an error about `const` not being supported because `use 'strict'` was enabled. To work around this, I had to use the `--harmony` flag for the `node` program.