### PR TITLE
Add callback to run

### DIFF
--- a/api.js
+++ b/api.js
@@ -435,8 +435,8 @@ dbmigrate.prototype = {
   /**
    * Executes the default routine.
    */
-  run: function () {
-    load('run')(this.internals, this.config);
+  run: function (callback) {
+    load('run')(this.internals, this.config, callback);
   }
 };
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -4,12 +4,14 @@ var log = require('db-migrate-shared').log;
 var optimist = require('optimist');
 var load = require('./');
 var transition = load('transition');
+Promise = require('bluebird');
 
-function run (internals, config) {
+function run (internals, config, callback) {
   var action = internals.argv._.shift();
   var folder = action.split(':');
 
   action = folder[0];
+  var toExecute = null;
 
   switch (action) {
     case 'transition':
@@ -20,10 +22,10 @@ function run (internals, config) {
         internals.matching = folder[1];
         internals.migrationMode = folder[1];
       }
-      load('create-migration')(internals, config);
+      toExecute = load('create-migration');
       break;
     case 'sync':
-      var executeSync = load('sync');
+      toExecute = load('sync');
 
       if (internals.argv._.length === 0) {
         log.error('Missing sync destination!');
@@ -38,7 +40,6 @@ function run (internals, config) {
         internals.migrationMode = folder[1];
       }
 
-      executeSync(internals, config);
       break;
     case 'up':
     case 'down':
@@ -60,11 +61,9 @@ function run (internals, config) {
       }
 
       if (action === 'up') {
-        var executeUp = load('up');
-        executeUp(internals, config);
+        toExecute = load('up');
       } else {
-        var executeDown = load('down');
-        executeDown(internals, config);
+        toExecute = load('down');
       }
       break;
 
@@ -73,7 +72,7 @@ function run (internals, config) {
         log.info('Please enter a valid command, i.e. db:create|db:drop');
       } else {
         internals.mode = folder[1];
-        load('db')(internals, config);
+        toExecute = load('db');
       }
       break;
     case 'seed':
@@ -86,9 +85,9 @@ function run (internals, config) {
         }
 
         internals.argv._.shift();
-        load('undo-seed')(internals, config);
+        toExecute = load('undo-seed');
       } else {
-        load('seed')(internals, config);
+        toExecute = load('seed');
       }
       break;
 
@@ -111,6 +110,12 @@ function run (internals, config) {
         process.exit(1);
       }
       break;
+  }
+
+  if (toExecute) {
+    toExecute(internals, config, callback);
+  } else {
+    callback();
   }
 }
 


### PR DESCRIPTION
This makes it much simpler to hook standard CLI behavior with custom behavior, as detailed in the docs: https://db-migrate.readthedocs.io/en/latest/API/programable/#run

Related: https://github.com/db-migrate/node-db-migrate/issues/313