### PR TITLE
Added dummy functions for fine, remove, removeMany

### DIFF
--- a/lib/interface/migratorInterface.js
+++ b/lib/interface/migratorInterface.js
@@ -116,7 +116,13 @@ MigratorInterface.prototype = {
 
   close: dummy,
 
-  insert: dummy
+  insert: dummy,
+
+  find: dummy,
+
+  remove: dummy,
+
+  removeMany: dummy
 };
 
 module.exports = MigratorInterface;


### PR DESCRIPTION
Related to https://github.com/db-migrate/mongodb/pull/24

MongoDB does not have a fallback like the SQL interfaces. There is no `remove`, `removeMany`, or `find` functions for MongoDB making removing records difficult.