### PR TITLE
When creating or dropping a database, set exit code to 1 only on error

### DIFF
--- a/lib/commands/db.js
+++ b/lib/commands/db.js
@@ -32,7 +32,7 @@ function executeDB (internals, config, callback) {
 
           db.close();
           if (typeof callback === 'function') callback(err);
-          else process.exit(1);
+          else process.exit(err ? 1 : 0);
         }
       );
     } else if (internals.mode === 'drop') {
@@ -51,7 +51,7 @@ function executeDB (internals, config, callback) {
 
           db.close();
           if (typeof callback === 'function') callback(err);
-          process.exit(1);
+          process.exit(err ? 1 : 0);
         }
       );
     }


### PR DESCRIPTION
This relates to #550. I took a stab at writing a test for this, but got stuck in stubbing out [the call to `db.createDatabase`](https://github.com/descriptinc/node-db-migrate/blob/ce81c86e52582050055d8c2ff2a04fa20487cd6b/lib/commands/db.js#L16-L20) on the `index.driver` callback. Any suggestions on how to do that, and I'll happily add a test.