### PR TITLE
fix: allow special chars in password or user string

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -11,6 +11,13 @@ exports.connect = function (config, PassedClass, callback) {
     internals = config.internals;
     config = config.config;
   }
+  
+  if (config.password) {
+    config.password = encodeURIComponent(config.password);
+  }
+  if (config.user) {
+    config.user = encodeURIComponent(config.user);
+  }
 
   driver.connect(config, internals, function (err, db) {
     if (err) {

--- a/connect.js
+++ b/connect.js
@@ -11,7 +11,7 @@ exports.connect = function (config, PassedClass, callback) {
     internals = config.internals;
     config = config.config;
   }
-  
+
   if (config.password) {
     config.password = encodeURIComponent(config.password);
   }


### PR DESCRIPTION
This commit fixes a bug where special chars like `$`, `*` or `^` would cause the library to crash