### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - 4
   - 6
   - 8
+  - 10
   - node
 
 notifications:
@@ -41,6 +41,8 @@ addons:
 
 before_install:
   - export CXX=g++-4.8; export CC=gcc-4.8;
+
+install: npm install
 
 before_script:
   - cp test/db.config.ci test/db.config.json


### PR DESCRIPTION
Test on Node.js 6, 8, 10 and 11 using `npm install`.

Node.js 4 already reached its EOL. See https://github.com/nodejs/Release/blob/master/README.md