### PR TITLE
support custom dotenv path

### DIFF
--- a/api.js
+++ b/api.js
@@ -5,6 +5,7 @@ var log = require('db-migrate-shared').log;
 require('pkginfo')(module, 'version'); // jshint ignore:line
 var Promise;
 var onComplete = load('on-complete');
+var config = require('rc')('db-migrate');
 
 // constant hooks for this file
 var APIHooks = {
@@ -37,9 +38,12 @@ function dbmigrate (plugins, isModule, options, callback) {
   this.internals.dbm = require('./');
   this.dataType = this.internals.dbm.dataType;
   this.version = this.internals.dbm.version;
-  dotenv.load({
-    silent: true
-  });
+
+  var dotenvConfig = { silent: true };
+  if (config.dotenvCustomPath) {
+    dotenvConfig.path = config.dotenvCustomPath;
+  }
+  dotenv.load(dotenvConfig);
 
   /* $lab:coverage:off$ */
   if (!options || !options.throwUncatched) load('helper/register-events')();


### PR DESCRIPTION
Fixes https://github.com/db-migrate/node-db-migrate/issues/517.

Uses `pkg-conf` to allow this sort of thing in the `package.json`:

```JSON
{
  "dbMigrate": {
    "dotenvCustomPath": "../../.env"
  }
}
```

The above example allows for usage in a typical monorepo setup, which has packages in `<root>/packages/*` and typically a single `.env` file in the monorepo root.

I didn't add any tests because I was a bit intimidated by the tests in `api_test.js` -- Lab is not a framework I'm familiar with at all, and the complexity of the setup/mocking/spy etc. was sort of formidable.  But the change here is really straightforward, and I think would help a lot of folks.