### PR TITLE
Convert to string before splitting name

### DIFF
--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -49,7 +49,7 @@ async function executeCreateMigration (internals, config) {
   const Migration = require('../template.js');
 
   internals.argv.title = internals.argv._.shift();
-  folder = internals.argv.title.split('/');
+  folder = internals.argv.title.toString().split('/');
 
   internals.argv.title = folder[folder.length - 2] || folder[0];
   path = migrationsDir;


### PR DESCRIPTION
Following https://github.com/db-migrate/node-db-migrate/issues/631

https://github.com/db-migrate/node-db-migrate/blob/master/lib/commands/create-migration.js#L52

### Problem
There was an issue when the name of the file was only number `db-migrate create 012` 
```[ERROR] TypeError: internals.argv.title.split is not a function```

### Solution
Convert the name to a String before splitting it.