### PR TITLE
Fix(#656) Ensure scoped migration created in subdirectory

### DIFF
--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -51,7 +51,7 @@ async function executeCreateMigration (internals, config) {
   internals.argv.title = internals.argv._.shift();
   folder = internals.argv.title.split('/');
 
-  internals.argv.title = folder[folder.length - 2] || folder[0];
+  internals.argv.title = folder[folder.length - 1] || folder[0];
   path = migrationsDir;
 
   if (folder.length > 1) {
@@ -61,6 +61,7 @@ async function executeCreateMigration (internals, config) {
       path += folder[i] + '/';
     }
   }
+  internals.argv['migrations-dir'] = path
 
   let templateType = Migration.TemplateType.DEFAULT_JS;
   if (

--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -39,13 +39,6 @@ async function executeCreateMigration (internals, config) {
     throw new Error("'migrationName' is required.");
   }
 
-  try {
-    await createMigrationDir(migrationsDir);
-  } catch (err) {
-    log.error('Failed to create migration directory at ', migrationsDir, err);
-    throw new Error('Failed to create migration directory.');
-  }
-
   const Migration = require('../template.js');
 
   internals.argv.title = internals.argv._.shift();
@@ -61,7 +54,14 @@ async function executeCreateMigration (internals, config) {
       path += folder[i] + '/';
     }
   }
-  internals.argv['migrations-dir'] = path
+  internals.argv['migrations-dir'] = path;
+
+  try {
+    await createMigrationDir(path);
+  } catch (err) {
+    log.error('Failed to create migration directory at ', migrationsDir, err);
+    throw new Error('Failed to create migration directory.');
+  }
 
   let templateType = Migration.TemplateType.DEFAULT_JS;
   if (

--- a/test/integration/create_test.js
+++ b/test/integration/create_test.js
@@ -216,6 +216,61 @@ lab.experiment('create', function () {
       });
     }
   );
+  lab.experiment(
+    'with scoped migration',
+    function () {
+      let exitCode;
+      lab.experiment('without a migration directory', function () {
+        let exitCode;
+
+        lab.before(function (done) {
+          wipeMigrations(function (err) {
+            Code.expect(err).to.be.null();
+            const configOption = path.join('--sql-file');
+            const db = dbMigrate('create', 'test/first migration', configOption);
+            // db.stderr.on('data', data => console.log(data.toString()));
+            // db.stdout.on('data', data => console.log(data.toString()));
+
+            db.on('exit', function (code) {
+              exitCode = code;
+              done();
+            });
+          });
+        });
+
+        lab.test('does not cause an error', function (done) {
+          Code.expect(exitCode).to.equal(0);
+          done();
+        });
+
+        lab.test('will create a new migration directory', function (done) {
+          const stats = fs.statSync(path.join(__dirname, 'migrations/test'));
+          Code.expect(stats.isDirectory()).to.be.true();
+          done();
+        });
+
+        lab.test('will create a new migration', function (done) {
+          const files = fs.readdirSync(path.join(__dirname, 'migrations/test'));
+          Code.expect(files.length).to.equal(2);
+          const file = files[0];
+          Code.expect(file).to.match(/first-migration\.js$/);
+          done();
+        });
+        lab.test('will create a new migration/test/sqls directory', function (done) {
+          const stats = fs.statSync(path.join(__dirname, 'migrations/test/sqls'));
+          Code.expect(stats.isDirectory()).to.be.true();
+          done();
+        });
+        lab.test('will create a new migration sql up file', function (done) {
+          const files = fs.readdirSync(path.join(__dirname, 'migrations/test/sqls'));
+          Code.expect(files.length).to.equal(2);
+          const file = files[1];
+          Code.expect(file).to.match(/first-migration-up\.sql$/);
+          done();
+        });
+      });
+    }
+  );
 
   lab.experiment(
     'with coffee-file option set to true as a command parameter',


### PR DESCRIPTION
Fix for bug: https://github.com/db-migrate/node-db-migrate/issues/656

Current if you call
db-migrate create someScope/aMigration --sql-file, the following is created:
* ./migrations/someScope/xxx-someScope.js
* ./migrations/sqls/xxx-someScope-up.sql
* ./migrations/sqls/xxx-someScope-down.sql

Instead, I expect:
* ./migrations/someScope/xxx-aMigration.js
* ./migrations/someScope/sqls/xxx-aMigration-up.sql
* ./migrations/someScope/sqls/xxx-aMigration-down.sql