### PR TITLE
Replace module imports with dynamic names to static

### DIFF
--- a/api.js
+++ b/api.js
@@ -2,10 +2,9 @@
 
 module.exports.version = require('./package.json').version;
 
-var load = require('./lib/commands');
 var log = require('db-migrate-shared').log;
 var Promise;
-var onComplete = load('on-complete');
+var onComplete = require('./lib/commands/on-complete');
 var config = require('rc')('db-migrate');
 
 // constant hooks for this file
@@ -20,7 +19,7 @@ var APIHooks = {
 
 function dbmigrate (plugins, isModule, options, callback) {
   var dotenv = require('dotenv');
-  var setDefaultArgv = load('set-default-argv');
+  var setDefaultArgv = require('./lib/commands/set-default-argv');
 
   this.internals = {
     onComplete: onComplete,
@@ -31,7 +30,7 @@ function dbmigrate (plugins, isModule, options, callback) {
   }
   var internals = this.internals;
 
-  this.internals.plugins = load('fn/plugin')(plugins);
+  this.internals.plugins = require('./lib/commands/fn/plugin')(plugins);
 
   if (typeof callback === 'function') this.internals.onComplete = callback;
   else if (typeof options === 'function') this.internals.onComplete = options;
@@ -47,7 +46,7 @@ function dbmigrate (plugins, isModule, options, callback) {
   dotenv.load(dotenvConfig);
 
   /* $lab:coverage:off$ */
-  if (!options || !options.throwUncatched) load('helper/register-events')();
+  if (!options || !options.throwUncatched) require('./lib/commands/helper/register-events')();
   /* $lab:coverage:on$ */
 
   if (typeof options === 'object') {
@@ -72,7 +71,7 @@ function dbmigrate (plugins, isModule, options, callback) {
     setDefaultArgv(this.internals);
   } else setDefaultArgv(this.internals, isModule);
 
-  this.config = load('helper/load-config')(
+  this.config = require('./lib/commands/helper/load-config')(
     require('./lib/config.js'),
     this.internals
   );
@@ -184,7 +183,7 @@ dbmigrate.prototype = {
    * Defaults to up all migrations if no count is given.
    */
   up: function (specification, opts, callback) {
-    var executeUp = load('up');
+    var executeUp = require('./lib/commands/up');
 
     if (arguments.length > 0) {
       if (typeof specification === 'string') {
@@ -214,7 +213,7 @@ dbmigrate.prototype = {
    * Defaults to up all migrations if no count is given.
    */
   down: function (specification, opts, callback) {
-    var executeDown = load('down');
+    var executeDown = require('./lib/commands/down');
 
     if (arguments.length > 0) {
       if (typeof specification === 'number') {
@@ -240,7 +239,7 @@ dbmigrate.prototype = {
   },
 
   check: function (specification, opts, callback) {
-    var executeCheck = load('check');
+    var executeCheck = require('./lib/commands/check');
 
     if (arguments.length > 0) {
       if (typeof specification === 'number') {
@@ -268,7 +267,7 @@ dbmigrate.prototype = {
    * Defaults to up all migrations if no count is given.
    */
   sync: function (specification, opts, callback) {
-    var executeSync = load('sync');
+    var executeSync = require('./lib/commands/sync');
 
     if (arguments.length > 0) {
       if (typeof specification === 'string') {
@@ -292,7 +291,7 @@ dbmigrate.prototype = {
    * Executes down for all currently migrated migrations.
    */
   reset: function (scope, callback) {
-    var executeDown = load('down');
+    var executeDown = require('./lib/commands/down');
 
     if (typeof scope === 'string') {
       this.internals.migrationMode = scope;
@@ -318,14 +317,14 @@ dbmigrate.prototype = {
    * Transition migrations to the latest defined protocol.
    */
   transition: function () {
-    load('transition')(this.internals);
+    require('./lib/commands/transition')(this.internals);
   },
 
   /**
    * Creates a correctly formatted migration
    */
   create: function (migrationName, scope, callback) {
-    var executeCreateMigration = load('create-migration');
+    var executeCreateMigration = require('./lib/commands/create-migration');
     if (typeof scope === 'function') {
       callback = scope;
     } else if (scope) {
@@ -343,7 +342,7 @@ dbmigrate.prototype = {
    * Creates a database of the given dbname.
    */
   createDatabase: function (dbname, callback) {
-    var executeDB = load('db');
+    var executeDB = require('./lib/commands/db');
     this.internals.argv._.push(dbname);
     this.internals.mode = 'create';
     return Promise.resolve(executeDB(this.internals, this.config)).asCallback(
@@ -355,7 +354,7 @@ dbmigrate.prototype = {
    * Drops a database of the given dbname.
    */
   dropDatabase: function (dbname, callback) {
-    var executeDB = load('db');
+    var executeDB = require('./lib/commands/db');
     this.internals.argv._.push(dbname);
     this.internals.mode = 'drop';
     return Promise.resolve(executeDB(this.internals, this.config)).asCallback(
@@ -392,7 +391,7 @@ dbmigrate.prototype = {
    * the passed mode.
    */
   seed: function (mode, scope, callback) {
-    var executeSeed = load('seed');
+    var executeSeed = require('./lib/commands/seed');
     if (scope) {
       this.internals.migrationMode = scope;
       this.internals.matching = scope;
@@ -408,7 +407,7 @@ dbmigrate.prototype = {
    * Execute the down function of currently executed seeds.
    */
   undoSeed: function (specification, scope, callback) {
-    var executeUndoSeed = load('undo-seed');
+    var executeUndoSeed = require('./lib/commands/undo-seed');
     if (arguments.length > 0) {
       if (typeof specification === 'number') {
         this.internals.argv.count = specification;
@@ -432,7 +431,7 @@ dbmigrate.prototype = {
    * Execute the reset function of currently executed seeds.
    */
   resetSeed: function (specification, scope, callback) {
-    var executeUndoSeed = load('undo-seed');
+    var executeUndoSeed = require('./lib/commands/undo-seed');
     if (arguments.length > 0) {
       if (typeof specification === 'number') {
         this.internals.argv.count = specification;
@@ -457,7 +456,7 @@ dbmigrate.prototype = {
    * Executes the default routine.
    */
   run: function () {
-    load('run')(this.internals, this.config);
+    require('./lib/commands/run')(this.internals, this.config);
   }
 };
 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,9 +1,0 @@
-'use strict';
-
-var path = require('path');
-
-function register (module) {
-  return require(path.resolve(__dirname, module));
-}
-
-module.exports = register;

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -2,8 +2,7 @@
 
 var log = require('db-migrate-shared').log;
 var optimist = require('optimist');
-var load = require('./');
-var transition = load('transition');
+var transition = require('./transition');
 
 function run (internals, config) {
   var action = internals.argv._.shift();
@@ -20,10 +19,10 @@ function run (internals, config) {
         internals.matching = folder[1];
         internals.migrationMode = folder[1];
       }
-      load('create-migration')(internals, config);
+      require('./create-migration')(internals, config);
       break;
     case 'sync':
-      var executeSync = load('sync');
+      var executeSync = require('./sync');
 
       if (internals.argv._.length === 0) {
         log.error('Missing sync destination!');
@@ -60,16 +59,16 @@ function run (internals, config) {
       }
 
       if (action === 'up') {
-        var executeUp = load('up');
+        var executeUp = require('./up');
         executeUp(internals, config);
       } else {
-        var executeDown = load('down');
+        var executeDown = require('./down');
         executeDown(internals, config);
       }
       break;
 
     case 'check':
-      var executeCheck = load('check');
+      var executeCheck = require('./check');
 
       if (folder[1]) {
         internals.matching = folder[1];
@@ -83,7 +82,7 @@ function run (internals, config) {
         log.info('Please enter a valid command, i.e. db:create|db:drop');
       } else {
         internals.mode = folder[1];
-        load('db')(internals, config);
+        require('./db')(internals, config);
       }
       break;
     case 'seed':
@@ -96,9 +95,9 @@ function run (internals, config) {
         }
 
         internals.argv._.shift();
-        load('undo-seed')(internals, config);
+        require('./undo-seed')(internals, config);
       } else {
-        load('seed')(internals, config);
+        require('./seed')(internals, config);
       }
       break;
 

--- a/lib/driver/index.js
+++ b/lib/driver/index.js
@@ -39,7 +39,13 @@ exports.connect = function (config, intern, callback) {
     );
   }
 
-  if (config.driver && typeof config.driver === 'object') {
+  var shouldSkipDriverImport =
+    intern.configObject &&
+    intern.configObject[intern.currentEnv] &&
+    typeof intern.configObject[intern.currentEnv].driver === 'object';
+  if (shouldSkipDriverImport) {
+    driver = intern.configObject[intern.currentEnv].driver;
+  } else if (config.driver && typeof config.driver === 'object') {
     log.verbose('require:', config.driver.require);
     driver = require(config.driver.require);
   } else {

--- a/lib/walker.js
+++ b/lib/walker.js
@@ -65,7 +65,7 @@ Walker.prototype = {
     ) {
       log.warn(
         'The driver you are using does not support the new state management. ' +
-          'Please raise an issue in the repository of your driver maintainer'
+        'Please raise an issue in the repository of your driver maintainer'
       );
 
       if (typeof this._driver._createList !== 'function') {
@@ -174,7 +174,17 @@ Walker.prototype = {
         const _meta = file.get()._meta || {};
         const version = _meta.version || 1;
         this.internals.modSchema = { i: {}, c: {}, f: {}, s: [] };
-        return require(`./executors/versioned/v${version}`).up(
+        let selectedExecutor;
+        const executorV1 = require('./executors/versioned/v1');
+        const executorV2 = require('./executors/versioned/v2');
+        if (version === 1) {
+          selectedExecutor = executorV1;
+        } else if (version === 2) {
+          selectedExecutor = executorV2;
+        } else {
+          throw new Error('Executor version is unknown');
+        }
+        return selectedExecutor.up(
           this,
           this.driver,
           file
@@ -218,7 +228,17 @@ Walker.prototype = {
         const _meta = file.get()._meta || {};
         const version = _meta.version || 1;
         this.internals.modSchema = { i: {}, c: {}, f: {}, s: [] };
-        return require(`./executors/versioned/v${version}`).down(
+        let selectedExecutor;
+        const executorV1 = require('./executors/versioned/v1');
+        const executorV2 = require('./executors/versioned/v2');
+        if (version === 1) {
+          selectedExecutor = executorV1;
+        } else if (version === 2) {
+          selectedExecutor = executorV2;
+        } else {
+          throw new Error('Executor version is unknown');
+        }
+        return selectedExecutor.down(
           this,
           this.driver,
           file

--- a/test/integration/api_test.js
+++ b/test/integration/api_test.js
@@ -22,7 +22,7 @@ lab.experiment('api', function () {
       var dbmigrate = stubApiInstance(
         true,
         {
-          up: upStub
+          './lib/commands/up': upStub
         },
         config
       );
@@ -205,7 +205,7 @@ lab.experiment('api', function () {
 function defaultExecParams (method) {
   return function (args, index) {
     var stubs = {};
-    stubs[method] = stub;
+    stubs['./lib/commands/' + method] = stub;
 
     var api = stubApiInstance(true, stubs);
 
@@ -235,24 +235,10 @@ function spyCallback (api, args) {
   }
 }
 
-function loader (stubs) {
-  var load = require('../../lib/commands');
-  var keys = Object.keys(stubs);
-  return function (module) {
-    var index = keys.indexOf(module);
-    if (index !== -1) {
-      return stubs[keys[index]];
-    }
-    return load(module);
-  };
-}
-
 function stubApiInstance (isModule, stubs, options, callback) {
   delete require.cache[require.resolve('../../api.js')];
   delete require.cache[require.resolve('optimist')];
-  var Mod = proxyquire('../../api.js', {
-    './lib/commands': loader(stubs)
-  });
+  var Mod = proxyquire('../../api.js', stubs);
   var plugins = {};
   options = options || {};
 


### PR DESCRIPTION
**Why:**

To allow `db-migrate` usage in projects that use [zeit/ncc](https://github.com/zeit/ncc) or [zeit/pkg](https://github.com/zeit/pkg) for bundling. These tools cannot correctly analyze and bundle modules that relies on imports like `require(path.resolve(__dirname, module));` that are used in [./lib/commands/index.js](https://github.com/db-migrate/node-db-migrate/blob/master/lib/commands/index.js#L6).

**Implementation details:**

- File `./lib/commands/index.js` is removed as unnecessary.
- All `./lib/commands/*/**` imports are rewritten as simple "require" without an intermediary.
- Stubs implementation in integration tests is fixed accordingly to changes (i.e new paths in imports).
- Drivers now can to be passed as an object (it creates tight coupling with driver module that wouldn't be included in a bundle otherwise)

**Notes**

- If you think these changes are unnecessary please feel free to close this PR.
- Not sure this PR follows all the guidelines and conventions, sorry for that.