### PR TITLE
fix(api): Added info about migration name at error.

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -248,7 +248,11 @@ Migrator.prototype = {
                     self.writeMigrationRecord.bind(self)
                   )(migration);
                 })
-                .then(self.driver.endMigration.bind(self.driver));
+                .then(self.driver.endMigration.bind(self.driver))
+                .catch(function (err) {
+                  log.error('Error at run up migration: ', migration.name);
+                  throw err;
+                });
             })
             .nodeify(callback);
         }

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -313,7 +313,11 @@ Migrator.prototype = {
                   self.deleteMigrationRecord.bind(self)
                 )(migration);
               })
-              .then(self.driver.endMigration.bind(self.driver));
+              .then(self.driver.endMigration.bind(self.driver))
+              .catch(function (err) {
+                log.error('Error at run down migration: ', migration.name);
+                throw err;
+              });
           })
           .nodeify(callback);
       }


### PR DESCRIPTION
fixes issue: #681 
Before the only way to know failed migration name was verbose mode.
But in our case it gives hundreds megabytes of unuseful stuff.