### PR TITLE
Ignore development files for npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
-.github
+.*
 test
 migrations
 VCSeeder
@@ -9,4 +9,8 @@ database.json
 *.sublime-project
 *.sublime-workspace
 archive
-.db-migraterc
+coverage.html
+Makefile
+*.md
+commitlint.config.js
+generateLoader.js


### PR DESCRIPTION
Here is the npm report for the package after that change:
```shell
npm notice === Tarball Contents === 
npm notice 1.0kB  bin/db-migrate                        
npm notice 1.1kB  LICENSE                               
npm notice 1.4kB  lib/transitions/1.js                  
npm notice 12.3kB api.js                                
npm notice 443B   lib/transitions/ask.js                
npm notice 264B   lib/commands/helper/assert.js         
npm notice 2.1kB  lib/chain.js                          
npm notice 1.4kB  lib/commands/check.js                 
npm notice 2.0kB  lib/class.js                          
npm notice 5.4kB  lib/config.js                         
npm notice 4.8kB  connect.js                            
npm notice 933B   lib/methods/v2/conventions.js         
npm notice 6.1kB  lib/commands/create-migration.js      
npm notice 1.6kB  lib/commands/db.js                    
npm notice 1.2kB  lib/commands/down.js                  
npm notice 5.0kB  lib/file.js                           
npm notice 928B   lib/commands/generated.js             
npm notice 2.1kB  index.js                              
npm notice 154B   lib/commands/index.js                 
npm notice 3.4kB  lib/driver/index.js                   
npm notice 8.4kB  lib/learn.js                          
npm notice 639B   lib/commands/helper/load-config.js    
npm notice 86B    lib/methods/v2/migrate.js             
npm notice 150B   lib/commands/helper/migration-hook.js 
npm notice 2.4kB  lib/interface/migratorInterface.js    
npm notice 734B   lib/commands/on-complete.js           
npm notice 994B   lib/commands/fn/plugin.js             
npm notice 358B   lib/commands/helper/register-events.js
npm notice 810B   lib/relation.js                       
npm notice 3.3kB  lib/commands/run.js                   
npm notice 1.2kB  lib/commands/seed.js                  
npm notice 4.0kB  lib/interface/seederInterface.js      
npm notice 5.4kB  lib/commands/set-default-argv.js      
npm notice 1.9kB  lib/driver/shadow.js                  
npm notice 3.7kB  lib/state.js                          
npm notice 2.2kB  lib/methods/v2/statetravel.js         
npm notice 1.4kB  lib/commands/sync.js                  
npm notice 8.4kB  lib/template.js                       
npm notice 1.4kB  lib/temputils.js                      
npm notice 114B   lib/commands/transition.js            
npm notice 2.2kB  lib/transitions/transitioner.js       
npm notice 2.1kB  lib/methods/v2/translatestate.js      
npm notice 2.9kB  lib/transitions/try-require.js        
npm notice 1.4kB  lib/commands/undo-seed.js             
npm notice 1.4kB  lib/commands/up.js                    
npm notice 1.2kB  lib/transitions/update-version.js     
npm notice 1.3kB  lib/executors/versioned/v1.js         
npm notice 2.6kB  lib/executors/versioned/v2.js         
npm notice 7.0kB  lib/walker.js                         
npm notice 1.9kB  package.json                          
npm notice 19.2kB CHANGELOG.md                          
npm notice 4.6kB  README.md                             
npm notice 228B   lib/transitions/snippets/setup.sjs
```

As I'm not familiar with the codebase, please confirm that I all and only what could be excluded actually is. I also covered previous versions (eg. Makefile) in case you want to cherry-pick it in other branches.