### PR TITLE
Replace var with let and const in template file

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -43,9 +43,9 @@ Template.prototype.defaultJsTemplate = function () {
   return [
     "'use strict';",
     '',
-    'var dbm;',
-    'var type;',
-    'var seed;',
+    'let dbm;',
+    'let type;',
+    'let seed;',
     '',
     '/**',
     '  * We receive the dbmigrate dependency from dbmigrate initially.',
@@ -80,12 +80,12 @@ Template.prototype.sqlFileLoaderTemplate = function () {
   return [
     "'use strict';",
     '',
-    'var dbm;',
-    'var type;',
-    'var seed;',
-    "var fs = require('fs');",
-    "var path = require('path');",
-    'var Promise;',
+    'let dbm;',
+    'let type;',
+    'let seed;',
+    "const fs = require('fs');",
+    "const path = require('path');",
+    'let Promise;',
     '',
     '/**',
     '  * We receive the dbmigrate dependency from dbmigrate initially.',
@@ -100,8 +100,8 @@ Template.prototype.sqlFileLoaderTemplate = function () {
     '',
     'exports.up = function(db) {',
     "  var filePath = path.join(__dirname, 'sqls', '" +
-      this.file.name.replace('.js', '') +
-      "-up.sql');",
+    this.file.name.replace('.js', '') +
+    "-up.sql');",
     '  return new Promise( function( resolve, reject ) {',
     "    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){",
     '      if (err) return reject(err);',
@@ -117,8 +117,8 @@ Template.prototype.sqlFileLoaderTemplate = function () {
     '',
     'exports.down = function(db) {',
     "  var filePath = path.join(__dirname, 'sqls', '" +
-      this.file.name.replace('.js', '') +
-      "-down.sql');",
+    this.file.name.replace('.js', '') +
+    "-down.sql');",
     '  return new Promise( function( resolve, reject ) {',
     "    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){",
     '      if (err) return reject(err);',
@@ -143,13 +143,13 @@ Template.prototype.sqlFileLoaderIgnoreOnInitTemplate = function () {
   return [
     "'use strict';",
     '',
-    'var dbm;',
-    'var type;',
-    'var seed;',
-    "var fs = require('fs');",
-    "var path = require('path');",
-    'var ignoreOnInit = false;',
-    'var Promise;',
+    'let dbm;',
+    'let type;',
+    'let seed;',
+    "const fs = require('fs');",
+    "const path = require('path');",
+    'let ignoreOnInit = false;',
+    'let Promise;',
     '',
     '/**',
     '  * We receive the dbmigrate dependency from dbmigrate initially.',
@@ -165,8 +165,8 @@ Template.prototype.sqlFileLoaderIgnoreOnInitTemplate = function () {
     '',
     'exports.up = function(db, callback) {',
     "  var filePath = path.join(__dirname + '/sqls/" +
-      this.file.name.replace('.js', '') +
-      "-up.sql');",
+    this.file.name.replace('.js', '') +
+    "-up.sql');",
     '  if (!ignoreOnInit) {',
     '    return new Promise( function( resolve, reject ) {',
     "       fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){",
@@ -188,8 +188,8 @@ Template.prototype.sqlFileLoaderIgnoreOnInitTemplate = function () {
     '',
     'exports.down = function(db, callback) {',
     "  var filePath = path.join(__dirname + '/sqls/" +
-      this.file.name.replace('.js', '') +
-      "-down.sql');",
+    this.file.name.replace('.js', '') +
+    "-down.sql');",
     '  return new Promise( function( resolve, reject ) {',
     "    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){",
     '      if (err) return reject(err);',
@@ -232,8 +232,8 @@ Template.prototype.coffeeSqlFileLoaderTemplate = function () {
     '',
     'exports.up = (db, callback) ->',
     '  filePath = path.join "#{__dirname}/sqls/' +
-      this.file.name.replace('.coffee', '') +
-      '-up.sql"',
+    this.file.name.replace('.coffee', '') +
+    '-up.sql"',
     "  fs.readFile filePath, {encoding: 'utf-8'}, (err,data) ->",
     '    return callback err if err',
     '',
@@ -241,8 +241,8 @@ Template.prototype.coffeeSqlFileLoaderTemplate = function () {
     '',
     'exports.down = (db, callback) ->',
     '  filePath = path.join "#{__dirname}/sqls/' +
-      this.file.name.replace('.coffee', '') +
-      '-down.sql"',
+    this.file.name.replace('.coffee', '') +
+    '-down.sql"',
 
     "  fs.readFile filePath, {encoding: 'utf-8'}, (err,data) ->",
     '    return callback err if err',


### PR DESCRIPTION
This change will replace the use of var with let and const in js files that get generated for new migrations.