### PR TITLE
feat: support ESM projects. resolves #721

### DIFF
--- a/lib/commands/create-migration.js
+++ b/lib/commands/create-migration.js
@@ -5,18 +5,38 @@ const log = require('db-migrate-shared').log;
 const mkdirp = Promise.promisify(require('mkdirp'));
 const fs = require('fs');
 const stat = Promise.promisify(fs.stat);
+const writeFile = Promise.promisify(fs.writeFile);
 const yargs = require('yargs');
 const util = require('util');
+const path = require('path');
 
 async function createMigrationDir (dir) {
   const res = await stat(dir).catch(_ => {
     return { err: true };
   });
   if (res && res.err === true) {
-    return mkdirp(dir);
+    await mkdirp(dir);
   }
 
-  return Promise.resolve();
+  // Create migrations/package.json to ensure migration files are
+  // executed as CJS and not ESM
+  // https://github.com/db-migrate/node-db-migrate/issues/721
+  const packageJsonPath = path.resolve(dir, 'package.json');
+
+  await stat(packageJsonPath).then(
+    async () => {
+      const packageJson = require(packageJsonPath);
+      packageJson.type = 'commonjs';
+      const packageJsonStr = JSON.stringify(packageJson, null, 2);
+      await writeFile(packageJsonPath, packageJsonStr, 'utf-8');
+    },
+    async (err) => {
+      const packageJson = JSON.stringify({
+        type: 'commonjs'
+      }, null, 2)
+      await writeFile(packageJsonPath, packageJson, 'utf-8');
+    }
+  )
 }
 
 async function executeCreateMigration (internals, config) {


### PR DESCRIPTION
See #721. The tests assumed a certain number of generated files in the migrations directory, so I updated them to search by file name instead of by length/index in the directory.