### PR TITLE
fix: missing space in warning message

### DIFF
--- a/lib/methods/v2/translatestate.js
+++ b/lib/methods/v2/translatestate.js
@@ -52,7 +52,7 @@ const methods = {
       );
       log.warn(
         `This index did not exist at the time of deleting it. ` +
-          `This can happen if an index was created by hand and then deleted` +
+          `This can happen if an index was created by hand and then deleted ` +
           `by db-migrate. Make sure to recreate it by hand to avoid any problems.`
       );
       return Promise.resolve();


### PR DESCRIPTION
Noticed this via [1].

[1] https://lgtm.com/projects/g/db-migrate/node-db-migrate/alerts?mode=list