### PR TITLE
Update db.js command to improve calling dbname

### DIFF
--- a/lib/commands/db.js
+++ b/lib/commands/db.js
@@ -8,6 +8,15 @@ function executeDB (internals, config, callback) {
 
   if (internals.argv._.length > 0) {
     internals.argv.dbname = internals.argv._.shift().toString();
+    // get the db name from .env using db:drop env.DB_NAME
+    if(internals.argv.dbname.includes('env.')){
+      var envDB = internals.argv.dbname.split('.')[1];
+      internals.argv.dbname = process.env[envDB];
+    }
+
+  } else if(config.getCurrent().settings.schema){
+    // get the db name from config json from schema setting without providing the dn name
+    internals.argv.dbname = config.getCurrent().settings.schema;
   } else {
     log.info('Error: You must enter a database name!');
     return;


### PR DESCRIPTION
## 1- get the dbname from .env using db:drop env.DB_NAME
> we can use it inside the script in package.json
```
"scripts": {
"db-test-create": "db-migrate -e create db:create env.DB_TEST",
"db-test-drop": "db-migrate -e create db:drop env.DB_TEST"
},
```

## 2- get the dbname from config json from schema setting without providing the dbname
> you should add in database.json schema settings 
```
"create": {
      "driver": "",
      "host": "";
      "user": "",
      "password": "",
      "schema": "db_name"
    }
```

> we can not provide the dbname  inside the script in package.json
```
"scripts": {
"db-test-create": "db-migrate -e create",
"db-test-drop": "db-migrate -e create"
},
```

