### PR TITLE
fix: Connection string with ssl broken for postgres

### DIFF
--- a/lib/driver/index.js
+++ b/lib/driver/index.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var internals = {};
 
 internals.mod = {};
@@ -33,6 +34,22 @@ exports.connect = function (config, intern, callback) {
 
   if (!config.user && config.username) {
     config.user = config.username;
+  }
+
+  if (config.sslcert || config.sslkey || config.sslrootcert || config.sslmode) {
+    config.ssl = {};
+  }
+
+  if (config.sslcert) {
+    config.ssl.cert = fs.readFileSync(config.sslcert).toString();
+  }
+
+  if (config.sslkey) {
+    config.ssl.key = fs.readFileSync(config.sslkey).toString();
+  }
+
+  if (config.sslrootcert) {
+    config.ssl.ca = fs.readFileSync(config.sslrootcert).toString();
   }
 
   if (config.driver === undefined) {


### PR DESCRIPTION
Connection strings with ssl are sent as sslrootcert, sslcert, sslkey and will be parsed as
```
  config = {
    sslrootcert: rootcert,
    sslcert: cert,
    sslkey: key,
```

pg expects ssl configurations sent as 
```
  ssl: {
    ca: rootCert,
    cert: cert,
    key: key,
  }
```

this change checks for ssl configs parsed from a connection string and changes it to the expected ssl object