### PR TITLE
Fixed Environment Variable Bug

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -103,7 +103,14 @@ function walkConfig (level) {
         );
       }
 
-      level[configEntry] = process.env[level[configEntry].ENV];
+      let processingVariable = process.env[level[configEntry].ENV];
+      if (processingVariable.toLowerCase() === 'true') {
+        processingVariable = true;
+      }
+      if (processingVariable.toLowerCase() === 'false') {
+        processingVariable = false;
+      }
+      level[configEntry] = processingVariable;
     } else if (level[configEntry] && typeof level[configEntry] === 'object') {
       level[configEntry] = walkConfig(level[configEntry]);
     }


### PR DESCRIPTION
Fixed issue when processing boolean environment variables.

On postgres (pg driver) and probably others, there is a bug when you try to do booleans. The drivers are checking 
`if(self.ssl){` //do stuff }`

Since you are passing them a string instead of a boolean when reading the environment variables it always passes. This Fixes that.