### PR TITLE
fix(deps): remove unused semver package to prevent be detected as a vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "parse-database-url": "~0.3.0",
         "rc": "^1.2.8",
         "resolve": "^1.19.0",
-        "semver": "^5.3.0",
         "tunnel-ssh": "^4.0.0",
         "yargs": "^17.5.1"
       },
@@ -5165,14 +5164,6 @@
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
       "dev": true
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/seq-queue": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "parse-database-url": "~0.3.0",
     "rc": "^1.2.8",
     "resolve": "^1.19.0",
-    "semver": "^5.3.0",
     "tunnel-ssh": "^4.0.0",
     "yargs": "^17.5.1"
   },


### PR DESCRIPTION
ref https://github.com/db-migrate/node-db-migrate/issues/821, semver is not used anymore, so we should be save to remove it