### PR TITLE
Pass callback to create/drop

### DIFF
--- a/api.js
+++ b/api.js
@@ -370,7 +370,7 @@ dbmigrate.prototype = {
     var executeDB = load('db');
     this.internals.argv._.push(dbname);
     this.internals.mode = 'create';
-    return Promise.resolve(executeDB(this.internals, this.config)).asCallback(
+    return Promise.resolve(executeDB(this.internals, this.config, callback)).asCallback(
       callback
     );
   },
@@ -382,7 +382,7 @@ dbmigrate.prototype = {
     var executeDB = load('db');
     this.internals.argv._.push(dbname);
     this.internals.mode = 'drop';
-    return Promise.resolve(executeDB(this.internals, this.config)).asCallback(
+    return Promise.resolve(executeDB(this.internals, this.config, callback)).asCallback(
       callback
     );
   },


### PR DESCRIPTION
I've noticed that the createDatabase exit after creating the db, this is an issue in my case as my script to run the migration check if the db exists, if it doesn't it create the db and then run the migrations, without the callback it just exits