### PR TITLE
fix: bypass database config check for version command

### DIFF
--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -8,6 +8,11 @@ if (process.argv.indexOf('--verbose') !== -1 ||
      process.argv.indexOf('-v') !== -1
 ) { global.verbose = true; }
 
+if (process.argv.length === 3 && process.argv[2] === 'version') {
+  console.log(require('../package.json').version);
+  process.exit(0);
+}
+
 resolve('db-migrate', {
 
   basedir: process.cwd()

--- a/lib/config.js
+++ b/lib/config.js
@@ -41,6 +41,7 @@ exports.load = function (config, currentEnv) {
 exports.loadFile = function (fileName, currentEnv, plugins) {
   var config;
 
+  
   try {
     fs.statSync(fileName);
   } catch (e) {


### PR DESCRIPTION
Hi maintainers,

This PR addresses issue **[#568](https://github.com/db-migrate/node-db-migrate/issues/568)**, where running `db-migrate version` fails if `database.json` is missing. Since the version command shouldn't require loading any database configuration, I've added a simple conditional check at the top of `db-migrate.js`:

```js
if (process.argv.length === 3 && process.argv[2] === 'version') {
  console.log(require('../package.json').version);
  process.exit(0);
}
```

This ensures that when the version command is invoked, it prints the version and exits early, avoiding any dependency on database.json. I've tested this change locally and confirmed that the version command now works as expected, even without a config file.

If this approach doesn’t align with your design goals, I’m happy to adjust the implementation or take another route based on your feedback.

Thanks for the great work on this project!

— Dhruv

